### PR TITLE
Improve media log: backlog, comments, faceted filters, edit in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 !.env.test
 .dev.vars*
 worker/worker-configuration.d.ts
+worker/backups/
 
 # Content
 src/content/*

--- a/src/library/components/media/CommentThread.svelte
+++ b/src/library/components/media/CommentThread.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import ToggleDiamond from '$components/media/ToggleDiamond.svelte';
+	import type { MediaComment } from '$types/types';
+	import { formatDate } from '$utils/media';
+
+	let {
+		comments,
+		isAdmin,
+		onadd,
+		ondelete
+	}: {
+		comments: MediaComment[];
+		isAdmin: boolean;
+		onadd: (body: string) => Promise<string | null>;
+		ondelete: (cid: string) => Promise<void>;
+	} = $props();
+
+	let open = $state(true);
+	let draft = $state('');
+	let posting = $state(false);
+	let error = $state('');
+	let confirmId = $state<string | null>(null);
+	let resetTimer: ReturnType<typeof setTimeout>;
+
+	async function post(event: SubmitEvent) {
+		event.preventDefault();
+		if (!draft.trim() || posting) return;
+		posting = true;
+		error = '';
+		const err = await onadd(draft.trim());
+		posting = false;
+		if (err) error = err;
+		else {
+			draft = '';
+			open = true;
+		}
+	}
+
+	function askDelete(cid: string) {
+		confirmId = cid;
+		clearTimeout(resetTimer);
+		resetTimer = setTimeout(() => (confirmId = null), 4000);
+	}
+</script>
+
+<div class="mt-2">
+	{#if comments.length > 0}
+		<button
+			onclick={() => (open = !open)}
+			class="flex cursor-pointer items-center gap-1.5 font-mono text-[0.65rem] transition-colors duration-200 hover:text-[--color-accent]"
+			style="color: var(--color-text-muted); background: none; border: none; opacity: 0.75;"
+		>
+			<ToggleDiamond {open} />
+			{comments.length} comment{comments.length > 1 ? 's' : ''}
+		</button>
+	{/if}
+
+	{#if open}
+		<div transition:slide={{ duration: 180 }}>
+			{#each comments as comment (comment.id)}
+				<div class="comment-branch group/comment relative mt-1.5 ml-[3px] pl-4">
+					<div class="flex items-baseline gap-2">
+						<span
+							class="font-mono text-[0.6rem]"
+							style="color: var(--color-text-muted); opacity: 0.6;"
+						>
+							{formatDate(comment.created_at)}
+						</span>
+						{#if isAdmin}
+							{#if confirmId === comment.id}
+								<span class="flex items-center gap-1 font-mono text-[0.6rem]">
+									<button
+										onclick={() => {
+											confirmId = null;
+											ondelete(comment.id);
+										}}
+										class="cursor-pointer px-1"
+										style="color: #b0413e; border: none; background: none; text-decoration: underline;"
+										>delete</button
+									>
+									<button
+										onclick={() => (confirmId = null)}
+										class="cursor-pointer px-1"
+										style="color: var(--color-text-muted); border: none; background: none; text-decoration: underline;"
+										>keep</button
+									>
+								</span>
+							{:else}
+								<button
+									onclick={() => askDelete(comment.id)}
+									class="cursor-pointer font-mono text-[0.6rem] transition-all duration-150 hover:text-[#b0413e] hover:!opacity-100 pointer-fine:opacity-0 pointer-fine:group-hover/comment:opacity-50"
+									style="color: var(--color-text-muted); background: none; border: none;"
+								>
+									delete
+								</button>
+							{/if}
+						{/if}
+					</div>
+					<p
+						class="text-[0.8rem] leading-relaxed whitespace-pre-line"
+						style="color: var(--color-text-muted);"
+					>
+						{comment.body}
+					</p>
+				</div>
+			{/each}
+
+			{#if isAdmin}
+				<form
+					onsubmit={post}
+					class="comment-branch ghost-form relative mt-1.5 ml-[3px] pl-4 {draft ? 'has-draft' : ''}"
+				>
+					<input
+						bind:value={draft}
+						placeholder={posting ? 'posting...' : 'add a comment... (enter to post)'}
+						disabled={posting}
+						class="ghost-input w-full py-1 text-[0.8rem] outline-none"
+					/>
+					{#if error}
+						<p class="font-mono text-[0.65rem]" style="color: #b0413e;">{error}</p>
+					{/if}
+				</form>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	/* Hacker News-style thread rail: a vertical line with a small elbow per node. */
+	.comment-branch::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 0;
+		bottom: -6px;
+		width: 1px;
+		background: var(--color-border-strong);
+	}
+
+	.comment-branch:last-child::before {
+		bottom: auto;
+		height: 0.7em;
+	}
+
+	.comment-branch::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 0.7em;
+		width: 9px;
+		height: 1px;
+		background: var(--color-border-strong);
+	}
+
+	/* Ghost add-comment branch: rail and input invisible until the entry row is
+	   hovered, the input has focus, or a draft is being typed. */
+	.ghost-form {
+		opacity: 0;
+		transition: opacity 150ms;
+	}
+
+	:global(.group:hover) .ghost-form,
+	.ghost-form:focus-within,
+	.ghost-form.has-draft {
+		opacity: 1;
+	}
+
+	.ghost-input {
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--color-border);
+		color: var(--color-text);
+		font-family: var(--font-body);
+		transition: border-color 150ms;
+	}
+
+	.ghost-input::placeholder {
+		color: var(--color-text-muted);
+		opacity: 0.6;
+	}
+
+	.ghost-input:focus {
+		border-bottom-color: var(--color-accent);
+	}
+
+	@media (pointer: coarse) {
+		.ghost-form {
+			opacity: 1;
+		}
+	}
+</style>

--- a/src/library/components/media/Heatmap.svelte
+++ b/src/library/components/media/Heatmap.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	import { localDateKey } from '$utils/media';
+
+	let {
+		entries,
+		selected = null,
+		onselect
+	}: {
+		entries: { title: string; added_at: string }[];
+		selected?: string | null;
+		onselect: (day: string | null) => void;
+	} = $props();
+
+	const GAP = 2;
+	const GUTTER = 24;
+	const MONTHS = [
+		'jan',
+		'feb',
+		'mar',
+		'apr',
+		'may',
+		'jun',
+		'jul',
+		'aug',
+		'sep',
+		'oct',
+		'nov',
+		'dec'
+	];
+
+	let gridWidth = $state(0);
+	let scrollLeft = $state(0);
+
+	let byDay = $derived.by(() => {
+		const map = new Map<string, string[]>();
+		for (const e of entries) {
+			const key = localDateKey(new Date(e.added_at));
+			map.set(key, [...(map.get(key) ?? []), e.title]);
+		}
+		return map;
+	});
+
+	let cells = $derived.by(() => {
+		const end = new Date();
+		end.setHours(0, 0, 0, 0);
+		const start = new Date(end);
+		start.setDate(start.getDate() - 364);
+		start.setDate(start.getDate() - ((start.getDay() + 6) % 7)); // align to Monday
+		const out: { key: string; count: number; month: number; future: boolean }[] = [];
+		const d = new Date(start);
+		while (d <= end || out.length % 7 !== 0) {
+			const key = localDateKey(d);
+			out.push({
+				key,
+				count: byDay.get(key)?.length ?? 0,
+				month: d.getMonth(),
+				future: d > end
+			});
+			d.setDate(d.getDate() + 1); // wall-clock safe across DST
+		}
+		return out;
+	});
+
+	let weeks = $derived(cells.length / 7);
+	// Stretch cells so the grid fills the available width.
+	let cell = $derived(Math.max(8, Math.floor((gridWidth - GUTTER - (weeks - 1) * GAP) / weeks)));
+
+	let monthLabels = $derived.by(() => {
+		const labels: { x: number; name: string }[] = [];
+		for (let week = 1; week * 7 < cells.length; week++) {
+			const prev = cells[(week - 1) * 7].month;
+			const cur = cells[week * 7].month;
+			if (cur !== prev) labels.push({ x: GUTTER + week * (cell + GAP), name: MONTHS[cur] });
+		}
+		return labels;
+	});
+
+	// Sequential single-hue scale: accent mixed into the surface, monotonic in
+	// both themes (light: darkens with count; dark: brightens with count).
+	const LEVELS = [0, 25, 45, 70, 100];
+	const level = (n: number) =>
+		`color-mix(in srgb, var(--color-accent) ${LEVELS[Math.min(n, 4)]}%, var(--color-surface))`;
+
+	// ─── Hover popover ───
+
+	let hovered = $state<{
+		key: string;
+		count: number;
+		titles: string[];
+		x: number;
+		y: number;
+	} | null>(null);
+
+	function enter(cellData: { key: string; count: number; future: boolean }, index: number) {
+		if (cellData.future) return;
+		const week = Math.floor(index / 7);
+		const day = index % 7;
+		hovered = {
+			key: cellData.key,
+			count: cellData.count,
+			titles: (byDay.get(cellData.key) ?? []).slice(0, 6),
+			x: GUTTER + week * (cell + GAP),
+			y: 14 + day * (cell + GAP)
+		};
+	}
+
+	function click(cellData: { key: string; count: number; future: boolean }) {
+		if (cellData.future || cellData.count === 0) return;
+		onselect(selected === cellData.key ? null : cellData.key);
+	}
+</script>
+
+<div
+	class="relative mb-4 rounded p-3"
+	style="border: 1px solid var(--color-border); background: var(--color-surface);"
+	onmouseleave={() => (hovered = null)}
+>
+	<!-- The grid stretches to fill the panel; on narrow screens it scrolls
+	     horizontally inside this wrapper (the popover compensates for scroll). -->
+	<div
+		class="overflow-x-auto"
+		bind:clientWidth={gridWidth}
+		onscroll={(e) => (scrollLeft = (e.currentTarget as HTMLElement).scrollLeft)}
+	>
+		<div class="relative mb-1 h-[12px]">
+			{#each monthLabels as m (m.x)}
+				<span
+					class="absolute top-0 font-mono text-[0.55rem]"
+					style="left: {m.x}px; color: var(--color-text-muted); opacity: 0.6;"
+				>
+					{m.name}
+				</span>
+			{/each}
+		</div>
+
+		<div class="flex">
+			<div
+				class="grid shrink-0 font-mono text-[0.5rem]"
+				style="grid-template-rows: repeat(7, {cell}px); row-gap: {GAP}px; width: {GUTTER}px; color: var(--color-text-muted); opacity: 0.6;"
+			>
+				<span style="grid-row: 1;">mon</span>
+				<span style="grid-row: 4;">thu</span>
+				<span style="grid-row: 7;">sun</span>
+			</div>
+			<div
+				class="grid min-w-0 grid-flow-col"
+				style="grid-template-rows: repeat(7, {cell}px); grid-auto-columns: {cell}px; gap: {GAP}px;"
+			>
+				{#each cells as c, i (c.key)}
+					<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+					<button
+						aria-label="{c.key}: {c.count} entries"
+						class="rounded-[2px] p-0 {c.count > 0 && !c.future
+							? 'cursor-pointer'
+							: 'cursor-default'}"
+						style="background: {c.future ? 'transparent' : level(c.count)};
+						border: 1px solid {c.future
+							? 'transparent'
+							: selected === c.key
+								? 'var(--color-text)'
+								: c.count > 0
+									? 'transparent'
+									: 'var(--color-border)'};"
+						onmouseover={() => enter(c, i)}
+						onfocus={() => enter(c, i)}
+						onclick={() => click(c)}
+					></button>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<div
+		class="mt-2 flex items-center gap-3 font-mono text-[0.6rem]"
+		style="color: var(--color-text-muted); opacity: 0.7;"
+	>
+		<span>last 12 months · {entries.length} entries</span>
+		{#if selected}
+			<button
+				onclick={() => onselect(null)}
+				class="cursor-pointer rounded px-1.5"
+				style="border: 1px solid var(--color-accent); color: var(--color-accent); background: none;"
+			>
+				{selected} ✕
+			</button>
+		{/if}
+	</div>
+
+	{#if hovered}
+		<div
+			class="pointer-events-none absolute z-10 max-w-[260px] rounded px-2.5 py-1.5"
+			style="left: {Math.max(0, Math.min(hovered.x - scrollLeft, gridWidth - 260)) + 12}px;
+				top: {hovered.y + 40}px;
+				background: var(--color-hero-bg); border: 1px solid var(--color-border-strong);
+				box-shadow: 0 2px 8px rgba(0,0,0,0.25);"
+		>
+			<p class="font-mono text-[0.6rem]" style="color: #9a928a;">
+				{hovered.key} · {hovered.count} entr{hovered.count === 1 ? 'y' : 'ies'}
+				{#if hovered.count > 0}<span style="opacity: 0.6;"> · click to filter</span>{/if}
+			</p>
+			{#each hovered.titles as title (title)}
+				<p class="truncate font-serif text-[0.75rem]" style="color: #e8e0d4;">{title}</p>
+			{/each}
+			{#if hovered.count > hovered.titles.length}
+				<p class="font-mono text-[0.6rem]" style="color: #9a928a;">
+					+{hovered.count - hovered.titles.length} more
+				</p>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/library/components/media/MediaForm.svelte
+++ b/src/library/components/media/MediaForm.svelte
@@ -1,0 +1,352 @@
+<script lang="ts">
+	import type { MediaEntry, MediaMeta } from '$types/types';
+	import { localDateKey } from '$utils/media';
+
+	let {
+		entry = null,
+		defaultStatus = 'done',
+		bare = false,
+		onsave,
+		oncancel,
+		onfetchmeta,
+		findByUrl,
+		oneditexisting
+	}: {
+		entry?: MediaEntry | null;
+		defaultStatus?: 'todo' | 'done';
+		bare?: boolean;
+		onsave: (payload: Record<string, unknown>) => Promise<string | null>;
+		oncancel: () => void;
+		onfetchmeta: (url: string) => Promise<MediaMeta | null>;
+		findByUrl?: (url: string) => MediaEntry | null;
+		oneditexisting?: (entry: MediaEntry) => void;
+	} = $props();
+
+	const TYPES = ['article', 'book', 'paper', 'film', 'video', 'podcast', 'repo', 'wiki', 'site'];
+	const today = localDateKey(new Date());
+	const origDate = entry ? localDateKey(new Date(entry.added_at)) : today;
+
+	let url = $state(entry?.url ?? '');
+	let title = $state(entry?.title ?? '');
+	let type = $state(entry?.type ?? 'article');
+	let author = $state(entry?.author ?? '');
+	let date = $state(origDate);
+	let topics = $state(entry?.topics.join(', ') ?? '');
+	let rating = $state(entry?.rating ?? 0);
+	let note = $state(entry?.note ?? '');
+	let status = $state<'todo' | 'done'>(entry?.status ?? defaultStatus);
+	// Publication year is no longer edited (the read date is the only date that
+	// matters), but existing values are carried through untouched.
+	const year = entry?.year ?? null;
+
+	let urlInput = $state<HTMLInputElement | null>(null);
+	let fetchingMeta = $state(false);
+	let quickAdding = $state(false);
+	let saving = $state(false);
+	let error = $state('');
+	let suggestion = $state('');
+
+	// URL is the entry's identity: flag when it matches another entry in the log.
+	let duplicate = $derived.by(() => {
+		if (!findByUrl || !url.trim()) return null;
+		const existing = findByUrl(url.trim());
+		return existing && existing.id !== entry?.id ? existing : null;
+	});
+
+	function resetFields() {
+		url = '';
+		title = '';
+		author = '';
+		date = today;
+		topics = '';
+		rating = 0;
+		note = '';
+		suggestion = '';
+		urlInput?.focus();
+	}
+
+	function payloadOf(overrides: Record<string, unknown> = {}) {
+		const payload: Record<string, unknown> = {
+			title,
+			type,
+			author,
+			url,
+			year,
+			topics: topics
+				.split(',')
+				.map((t) => t.trim())
+				.filter(Boolean),
+			rating: rating || null,
+			note,
+			status,
+			...overrides
+		};
+		// Only send added_at when the picked day changed, so an untouched edit
+		// preserves the exact original timestamp (server-side COALESCE).
+		if (date && date !== origDate) {
+			payload.added_at = date === today ? new Date().toISOString() : `${date}T12:00:00.000Z`;
+		}
+		return payload;
+	}
+
+	/** Paste a link, one click: fetch metadata and save immediately. */
+	async function quickAdd() {
+		if (!url.trim() || quickAdding || duplicate) return;
+		quickAdding = true;
+		error = '';
+		const meta = await onfetchmeta(url.trim());
+		// Redirects can land on the canonical URL of an entry we already have.
+		if (meta?.url && findByUrl?.(meta.url)) {
+			quickAdding = false;
+			url = meta.url;
+			return;
+		}
+		const fallbackTitle = url
+			.trim()
+			.replace(/^https?:\/\/(www\.)?/, '')
+			.split(/[/?#]/)[0];
+		const err = await onsave(
+			payloadOf({
+				title: meta?.title || fallbackTitle,
+				type: meta?.type || type,
+				author: meta?.author ?? '',
+				url: meta?.url || url.trim(),
+				topics: [],
+				rating: null,
+				note: ''
+			})
+		);
+		quickAdding = false;
+		if (err) error = err;
+		else resetFields();
+	}
+
+	async function fetchMeta() {
+		if (!url.trim() || fetchingMeta) return;
+		fetchingMeta = true;
+		error = '';
+		const meta = await onfetchmeta(url.trim());
+		fetchingMeta = false;
+		if (!meta) {
+			error = 'metadata fetch failed';
+			return;
+		}
+		if (meta.warning) error = meta.warning;
+		if (meta.title) title = meta.title;
+		if (meta.author) author = meta.author;
+		if (meta.url) url = meta.url;
+		// Only apply the suggested type while the field still holds the default.
+		if (meta.type && type === 'article') type = meta.type;
+		// Description is offered, never silently applied over an existing note.
+		if (meta.description) suggestion = meta.description;
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (saving) return;
+		if (duplicate) {
+			error = 'this url is already in the log';
+			return;
+		}
+		saving = true;
+		error = '';
+		const err = await onsave(payloadOf());
+		saving = false;
+		if (err) error = err;
+		else if (!entry) resetFields();
+	}
+</script>
+
+<form
+	onsubmit={handleSubmit}
+	class="flex flex-col gap-1.5 {bare
+		? 'p-3'
+		: 'rounded p-3'} [&_.mi]:min-w-0 [&_.mi]:px-1 [&_.mi]:py-1.5 [&_.mi]:text-[0.8rem] [&_.mi]:outline-none"
+	style="{bare ? '' : 'border: 1px solid var(--color-border-strong);'} background: {bare
+		? 'transparent'
+		: 'var(--color-surface)'};
+		--mi-border: var(--color-border);"
+>
+	<div class="flex items-center gap-1.5">
+		<input
+			bind:this={urlInput}
+			bind:value={url}
+			type="url"
+			placeholder={entry ? 'https://...' : 'paste a link…'}
+			class="mi flex-1"
+		/>
+		{#if !entry}
+			<button
+				type="button"
+				onclick={quickAdd}
+				disabled={quickAdding || fetchingMeta || !url.trim()}
+				title="fetch metadata and save in one step"
+				class="h-[30px] shrink-0 cursor-pointer rounded px-2.5 font-mono text-[0.65rem] transition-colors duration-200 disabled:cursor-default disabled:opacity-40"
+				style="border: 1px solid var(--color-accent); color: var(--color-accent); background: none;"
+			>
+				{quickAdding ? '…' : 'quick add'}
+			</button>
+		{/if}
+		<button
+			type="button"
+			onclick={fetchMeta}
+			disabled={fetchingMeta || quickAdding || !url.trim()}
+			title="fill the fields from the page"
+			class="h-[30px] shrink-0 cursor-pointer rounded px-2.5 font-mono text-[0.65rem] transition-colors duration-200 hover:text-[--color-accent] disabled:cursor-default disabled:opacity-40"
+			style="border: 1px solid var(--color-border-strong); color: var(--color-text-muted); background: none;"
+		>
+			{fetchingMeta ? '…' : 'fetch'}
+		</button>
+	</div>
+
+	{#if duplicate}
+		<div
+			class="flex flex-wrap items-center gap-1.5 font-mono text-[0.65rem]"
+			style="color: var(--color-text-muted);"
+		>
+			<span style="color: var(--color-accent);">◆</span>
+			<span>already logged: “{duplicate.title}”</span>
+			{#if oneditexisting}
+				<button
+					type="button"
+					onclick={() => oneditexisting(duplicate)}
+					class="cursor-pointer underline transition-colors duration-150 hover:text-[--color-accent]"
+					style="background: none; border: none; color: inherit;"
+				>
+					edit it
+				</button>
+			{/if}
+		</div>
+	{/if}
+
+	<input bind:value={title} required placeholder="Title *" class="mi" />
+
+	<div class="flex flex-wrap gap-1.5">
+		<input bind:value={type} list="media-types" placeholder="type" class="mi w-[92px]" />
+		<datalist id="media-types">
+			{#each TYPES as t (t)}
+				<option value={t}></option>
+			{/each}
+		</datalist>
+		<input bind:value={author} placeholder="author" class="mi min-w-[120px] flex-1" />
+		<input bind:value={date} type="date" max={today} title="date read" class="mi w-[132px]" />
+	</div>
+
+	<div class="flex flex-wrap items-stretch gap-1.5">
+		<input
+			bind:value={topics}
+			placeholder="topics, comma, separated"
+			class="mi min-w-[140px] flex-1"
+		/>
+		<!-- Rating sits on the same underline as the other fields. -->
+		<span
+			class="flex shrink-0 items-center px-1"
+			style="border-bottom: 1px solid var(--color-border);"
+		>
+			{#each [1, 2, 3, 4, 5] as star (star)}
+				<button
+					type="button"
+					aria-label="rate {star}"
+					onclick={() => (rating = rating === star ? 0 : star)}
+					class="flex h-6 w-[18px] cursor-pointer items-center justify-center text-[0.8rem] transition-colors duration-150"
+					style="background: none; border: none; color: {rating >= star
+						? 'var(--color-accent)'
+						: 'var(--color-border-strong)'};"
+				>
+					◆
+				</button>
+			{/each}
+		</span>
+	</div>
+
+	<textarea bind:value={note} placeholder="note" rows="2" class="mi resize-y"></textarea>
+
+	{#if suggestion && !note.trim()}
+		<div class="flex items-start gap-2 text-[0.72rem]" style="color: var(--color-text-muted);">
+			<span class="min-w-0 flex-1 italic">“{suggestion.slice(0, 160)}…”</span>
+			<button
+				type="button"
+				onclick={() => {
+					note = suggestion;
+					suggestion = '';
+				}}
+				class="shrink-0 cursor-pointer font-mono text-[0.62rem] underline transition-colors duration-200 hover:text-[--color-accent]"
+				style="border: none; background: none; color: inherit;"
+			>
+				use
+			</button>
+		</div>
+	{/if}
+
+	{#if error || entry}
+		<div class="flex flex-wrap items-center gap-2">
+			{#if error}
+				<p class="font-mono text-[0.65rem]" style="color: #b0413e;">{error}</p>
+			{/if}
+			{#if entry}
+				<!-- Status is set by the active tab when adding; editing can move an
+			     entry back to the backlog. -->
+				<button
+					type="button"
+					onclick={() => (status = status === 'done' ? 'todo' : 'done')}
+					class="cursor-pointer rounded px-2 py-0.5 font-mono text-[0.62rem] transition-colors duration-150"
+					style="border: 1px solid {status === 'todo'
+						? 'var(--color-accent)'
+						: 'var(--color-border)'}; color: {status === 'todo'
+						? 'var(--color-accent)'
+						: 'var(--color-text-muted)'}; background: none;"
+				>
+					{status === 'todo' ? '◆ to read' : '◇ to read'}
+				</button>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="flex gap-1.5">
+		<!-- Adding: the panel stays open, so the secondary action empties the
+		     fields. Editing: it truly cancels and restores the row. -->
+		<button
+			type="button"
+			onclick={entry ? oncancel : resetFields}
+			class="h-9 flex-1 cursor-pointer rounded font-mono text-[0.7rem] tracking-[0.05em] transition-colors duration-200 hover:text-[--color-accent]"
+			style="border: 1px solid var(--color-border); color: var(--color-text-muted); background: none;"
+		>
+			{entry ? 'cancel' : 'clear'}
+		</button>
+		<button
+			type="submit"
+			disabled={saving}
+			class="h-9 flex-1 cursor-pointer rounded font-mono text-[0.7rem] tracking-[0.05em] transition-colors duration-200 disabled:opacity-40"
+			style="border: 1px solid var(--color-accent); color: var(--color-accent); background: none;"
+		>
+			{saving ? '…' : entry ? 'update' : 'save'}
+		</button>
+	</div>
+</form>
+
+<style>
+	/* Underline fields keep the form quiet next to the entry list. */
+	form :global(.mi) {
+		border: none;
+		border-bottom: 1px solid var(--color-border);
+		background: transparent;
+		color: var(--color-text);
+		font-family: var(--font-body);
+		border-radius: 0;
+		transition: border-color 150ms;
+	}
+
+	form :global(.mi:focus) {
+		border-bottom-color: var(--color-accent);
+	}
+
+	form :global(textarea.mi) {
+		border: 1px solid var(--color-border);
+		border-radius: 4px;
+		padding: 6px 8px;
+	}
+
+	form :global(textarea.mi:focus) {
+		border-color: var(--color-accent);
+	}
+</style>

--- a/src/library/components/media/MediaRow.svelte
+++ b/src/library/components/media/MediaRow.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import TopicPill from '$components/global/TopicPill.svelte';
+	import CommentThread from '$components/media/CommentThread.svelte';
+	import type { MediaEntry } from '$types/types';
+	import { compactDate } from '$utils/media';
+
+	let {
+		entry,
+		isAdmin,
+		ontopic,
+		onedit,
+		ondelete,
+		onaddcomment,
+		ondeletecomment,
+		onmarkread
+	}: {
+		entry: MediaEntry;
+		isAdmin: boolean;
+		ontopic: (topic: string) => void;
+		onedit: (entry: MediaEntry) => void;
+		ondelete: (entry: MediaEntry) => Promise<boolean>;
+		onaddcomment: (entry: MediaEntry, body: string) => Promise<string | null>;
+		ondeletecomment: (entry: MediaEntry, cid: string) => Promise<void>;
+		onmarkread?: (entry: MediaEntry) => Promise<void>;
+	} = $props();
+
+	let markingRead = $state(false);
+
+	async function markRead() {
+		if (!onmarkread || markingRead) return;
+		markingRead = true;
+		await onmarkread(entry);
+		markingRead = false;
+	}
+
+	let confirmDelete = $state(false);
+	let deleting = $state(false);
+	let deleteError = $state(false);
+	let copied = $state(false);
+	let resetTimer: ReturnType<typeof setTimeout>;
+	let copyTimer: ReturnType<typeof setTimeout>;
+
+	let displayUrl = $derived(entry.url.replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, ''));
+
+	async function copyUrl() {
+		try {
+			await navigator.clipboard.writeText(entry.url);
+			copied = true;
+			clearTimeout(copyTimer);
+			copyTimer = setTimeout(() => (copied = false), 1500);
+		} catch {
+			// clipboard unavailable; the link itself stays selectable
+		}
+	}
+
+	function askDelete() {
+		confirmDelete = true;
+		deleteError = false;
+		clearTimeout(resetTimer);
+		resetTimer = setTimeout(() => (confirmDelete = false), 4000);
+	}
+
+	async function confirmedDelete() {
+		clearTimeout(resetTimer);
+		deleting = true;
+		const ok = await ondelete(entry);
+		deleting = false;
+		confirmDelete = false;
+		if (!ok) deleteError = true;
+	}
+</script>
+
+<div class="group py-4" style="border-bottom: 1px solid var(--color-border);">
+	<div class="flex gap-3">
+		<div class="flex w-[76px] shrink-0 flex-col gap-0.5 pt-1">
+			<span
+				class="font-mono text-[0.65rem] whitespace-nowrap"
+				style="color: var(--color-text-muted);"
+			>
+				{compactDate(entry.added_at)}
+			</span>
+			<span class="font-mono text-[0.6rem]" style="color: var(--color-text-muted); opacity: 0.4;">
+				{entry.type}
+			</span>
+		</div>
+
+		<div class="min-w-0 flex-1">
+			<!-- Inline flow: when the title wraps, the author continues on its last line. -->
+			<p class="leading-snug">
+				{#if entry.url}
+					<a
+						href={entry.url}
+						target="_blank"
+						rel="noreferrer"
+						class="font-serif text-[1.1rem] font-semibold transition-colors duration-200 hover:text-[--color-accent]"
+						style="color: var(--color-text);"
+					>
+						{entry.title}
+					</a>
+				{:else}
+					<span class="font-serif text-[1.1rem] font-semibold" style="color: var(--color-text);">
+						{entry.title}
+					</span>
+				{/if}
+				{#if entry.author}
+					<span
+						class="ml-1 font-serif text-[0.8rem] whitespace-nowrap italic"
+						style="color: var(--color-text-muted); opacity: 0.85;"
+					>
+						{entry.author}
+					</span>
+				{/if}
+			</p>
+
+			{#if entry.url}
+				<span class="flex items-center gap-2">
+					<a
+						href={entry.url}
+						target="_blank"
+						rel="noreferrer"
+						class="external min-w-0 truncate font-mono text-[0.65rem] font-light transition-colors duration-200 hover:text-[--color-accent]"
+						style="color: var(--color-text-muted); opacity: 0.65;"
+					>
+						{displayUrl}
+					</a>
+					<button
+						onclick={copyUrl}
+						title="copy link"
+						class="shrink-0 cursor-pointer font-mono text-[0.6rem] transition-all duration-150 hover:!opacity-100 pointer-fine:opacity-0 pointer-fine:group-hover:opacity-50"
+						style="color: {copied
+							? 'var(--color-accent)'
+							: 'var(--color-text-muted)'}; background: none; border: none;"
+					>
+						{copied ? 'copied ◆' : 'copy'}
+					</button>
+				</span>
+			{/if}
+
+			{#if entry.note}
+				<p class="mt-1 text-[0.8rem] leading-relaxed" style="color: var(--color-text-muted);">
+					{entry.note}
+				</p>
+			{/if}
+
+			{#if entry.topics.length > 0}
+				<div class="mt-1.5 flex flex-wrap gap-1">
+					{#each entry.topics as topic (topic)}
+						<TopicPill {topic} disabled onclick={ontopic} />
+					{/each}
+				</div>
+			{/if}
+
+			{#if deleteError}
+				<p
+					class="mt-1 font-mono text-[0.7rem]"
+					style="color: #b0413e;"
+					transition:fade={{ duration: 150 }}
+				>
+					delete failed, try again
+				</p>
+			{/if}
+
+			{#if entry.comments.length > 0 || isAdmin}
+				<CommentThread
+					comments={entry.comments}
+					{isAdmin}
+					onadd={(body) => onaddcomment(entry, body)}
+					ondelete={(cid) => ondeletecomment(entry, cid)}
+				/>
+			{/if}
+		</div>
+
+		<span class="flex shrink-0 items-start gap-2 pt-0.5">
+			{#if isAdmin && entry.status === 'todo' && onmarkread}
+				<button
+					onclick={markRead}
+					disabled={markingRead}
+					class="cursor-pointer rounded px-2 py-1 pt-1 font-mono text-[0.65rem] transition-colors duration-150 disabled:opacity-50"
+					style="border: 1px solid var(--color-accent); color: var(--color-accent); background: none;"
+				>
+					{markingRead ? '...' : '◆ mark read'}
+				</button>
+			{/if}
+			{#if entry.rating && entry.status === 'done'}
+				<span class="pt-1.5 text-[0.65rem] tracking-[0.12em]">
+					{#each [1, 2, 3, 4, 5] as star (star)}
+						<span
+							style="color: {entry.rating >= star
+								? 'var(--color-accent)'
+								: 'var(--color-border-strong)'};">◆</span
+						>
+					{/each}
+				</span>
+			{/if}
+			{#if isAdmin}
+				{#if confirmDelete}
+					<span
+						class="flex items-center gap-1.5 pt-0.5 font-mono text-[0.7rem]"
+						in:fade={{ duration: 150 }}
+					>
+						<button
+							onclick={confirmedDelete}
+							disabled={deleting}
+							class="cursor-pointer rounded px-2 py-1 disabled:opacity-50"
+							style="color: #b0413e; border: 1px solid #b0413e; background: none;"
+						>
+							{deleting ? '...' : 'delete'}
+						</button>
+						<button
+							onclick={() => (confirmDelete = false)}
+							disabled={deleting}
+							class="cursor-pointer rounded px-2 py-1"
+							style="color: var(--color-text-muted); border: 1px solid var(--color-border); background: none;"
+						>
+							keep
+						</button>
+					</span>
+				{:else}
+					<span
+						class="row-actions flex items-center gap-1 pt-1 font-mono text-[0.65rem] transition-opacity duration-200 pointer-fine:opacity-0 pointer-fine:group-hover:opacity-100"
+						style="color: var(--color-text-muted);"
+					>
+						<button
+							onclick={() => onedit(entry)}
+							class="cursor-pointer px-1.5 py-1 transition-colors duration-150 hover:text-[--color-accent]"
+							style="background: none; border: none; color: inherit;"
+						>
+							edit
+						</button>
+						<span style="opacity: 0.35; font-size: 0.5rem;">◆</span>
+						<button
+							onclick={askDelete}
+							class="cursor-pointer px-1.5 py-1 transition-colors duration-150 hover:text-[#b0413e]"
+							style="background: none; border: none; color: inherit;"
+						>
+							delete
+						</button>
+					</span>
+				{/if}
+			{/if}
+		</span>
+	</div>
+</div>
+
+<style>
+	/* North-east arrow appended via CSS mask so it inherits the link color. */
+	.external::after {
+		content: '';
+		display: inline-block;
+		width: 0.85em;
+		height: 0.85em;
+		margin-left: 0.2em;
+		vertical-align: middle;
+		background-color: currentColor;
+		-webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M7 17 17 7M17 7H9M17 7v8'/></svg>")
+			no-repeat center / contain;
+		mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M7 17 17 7M17 7H9M17 7v8'/></svg>")
+			no-repeat center / contain;
+	}
+</style>

--- a/src/library/components/media/ToggleDiamond.svelte
+++ b/src/library/components/media/ToggleDiamond.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	// Collapse affordance in the site's geometric vocabulary: a hollow diamond
+	// fills in when the section is open. No box, no rotation, no chevron.
+	// Accent tone is reserved for "this facet is filtering", not for mere open state.
+	let { open = false, tone = 'muted' }: { open?: boolean; tone?: 'muted' | 'accent' } = $props();
+</script>
+
+<span
+	aria-hidden="true"
+	class="inline-flex shrink-0 items-center justify-center text-[0.6rem] leading-none transition-colors duration-200"
+	style="color: {open
+		? tone === 'accent'
+			? 'var(--color-accent)'
+			: 'var(--color-text-muted)'
+		: 'var(--color-border-strong)'};"
+>
+	{open ? '◆' : '◇'}
+</span>

--- a/src/library/types/types.ts
+++ b/src/library/types/types.ts
@@ -178,6 +178,12 @@ export interface SectionLoadReturn {
 export type TreeNode = Record<string, any[]> | TreeNode[]; // Recursive structure
 export type ConvertedNode = { label: string; items: ConvertedNode[] | any[] };
 
+export interface MediaComment {
+	id: string;
+	body: string;
+	created_at: string;
+}
+
 export interface MediaEntry {
 	id: string;
 	title: string;
@@ -188,5 +194,20 @@ export interface MediaEntry {
 	topics: string[];
 	rating: number | null;
 	note: string;
+	status: 'todo' | 'done';
 	added_at: string;
+	comments: MediaComment[];
+}
+
+export type MediaSortKey = 'added' | 'year' | 'rating' | 'title';
+
+export interface MediaMeta {
+	title: string;
+	author: string;
+	site: string;
+	url: string;
+	type: string;
+	description: string;
+	published: string;
+	warning?: string;
 }

--- a/src/library/utils/media.ts
+++ b/src/library/utils/media.ts
@@ -5,3 +5,114 @@ export const MEDIA_API =
 	import.meta.env.VITE_MEDIA_API ?? 'https://garden-media.mlhoutel.workers.dev';
 
 export const MEDIA_TOKEN_KEY = 'garden-media-token';
+export const MEDIA_CACHE_KEY = 'garden-media-cache';
+
+/** Canonical form of a URL for duplicate detection: host (no www) + path (no trailing /) + query. */
+export function normalizeUrl(raw: string): string {
+	try {
+		const u = new URL(raw.trim());
+		return (
+			u.hostname.toLowerCase().replace(/^www\./, '') + u.pathname.replace(/\/+$/, '') + u.search
+		);
+	} catch {
+		return raw
+			.trim()
+			.toLowerCase()
+			.replace(/^https?:\/\//, '')
+			.replace(/^www\./, '')
+			.replace(/\/+$/, '');
+	}
+}
+
+/**
+ * Pack variable-width items into rows of a fixed capacity, first-fit with
+ * look-ahead: keeps the incoming (importance) order roughly intact while
+ * pulling later, smaller items forward to fill the gap at a row's end.
+ */
+export function packRows<T>(
+	items: T[],
+	capacity: number,
+	widthOf: (item: T) => number,
+	gap = 4
+): T[][] {
+	const remaining = [...items];
+	const rows: T[][] = [];
+	while (remaining.length > 0) {
+		const row: T[] = [];
+		let used = 0;
+		let i = 0;
+		while (i < remaining.length) {
+			const width = widthOf(remaining[i]);
+			if (row.length === 0 || used + gap + width <= capacity) {
+				used += (row.length === 0 ? 0 : gap) + width;
+				row.push(remaining[i]);
+				remaining.splice(i, 1);
+			} else {
+				i++;
+			}
+		}
+		rows.push(row);
+	}
+	return rows;
+}
+
+/** Non-secret token fingerprint (djb2) so the cache invalidates when the token changes. */
+function tokenFingerprint(token: string): string {
+	let h = 5381;
+	for (let i = 0; i < token.length; i++) h = ((h << 5) + h + token.charCodeAt(i)) >>> 0;
+	return h.toString(16);
+}
+
+interface MediaCache {
+	v: number;
+	entries: unknown[];
+	role: 'admin' | 'reader';
+	ts: number;
+	tok: string;
+}
+
+export function readMediaCache(token: string): MediaCache | null {
+	try {
+		const cache = JSON.parse(localStorage.getItem(MEDIA_CACHE_KEY) ?? '') as MediaCache;
+		if (cache?.v !== 1 || cache.tok !== tokenFingerprint(token) || !Array.isArray(cache.entries)) {
+			return null;
+		}
+		return cache;
+	} catch {
+		return null;
+	}
+}
+
+export function writeMediaCache(entries: unknown[], role: 'admin' | 'reader', token: string): void {
+	try {
+		localStorage.setItem(
+			MEDIA_CACHE_KEY,
+			JSON.stringify({ v: 1, entries, role, ts: Date.now(), tok: tokenFingerprint(token) })
+		);
+	} catch {
+		// quota exceeded or storage unavailable: the cache is only an optimization
+	}
+}
+
+export function clearMediaCache(): void {
+	localStorage.removeItem(MEDIA_CACHE_KEY);
+}
+
+/** Local calendar date (YYYY-MM-DD) of a Date; never use toISOString().slice for this. */
+export function localDateKey(d: Date): string {
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** Compact dd/mm/yyyy display date. */
+export function compactDate(iso: string): string {
+	const d = new Date(iso);
+	return `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`;
+}
+
+export function formatDate(iso: string): string {
+	return new Date(iso).toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	});
+}

--- a/src/routes/media/+page.svelte
+++ b/src/routes/media/+page.svelte
@@ -1,56 +1,264 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import TopicPill from '$components/global/TopicPill.svelte';
-	import { MEDIA_API, MEDIA_TOKEN_KEY } from '$utils/media';
-	import type { MediaEntry } from '$types/types';
+	import { onMount, tick } from 'svelte';
+	import { slide } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import MediaForm from '$components/media/MediaForm.svelte';
+	import MediaRow from '$components/media/MediaRow.svelte';
+	import Heatmap from '$components/media/Heatmap.svelte';
+	import ToggleDiamond from '$components/media/ToggleDiamond.svelte';
+	import {
+		MEDIA_API,
+		MEDIA_TOKEN_KEY,
+		localDateKey,
+		normalizeUrl,
+		packRows,
+		readMediaCache,
+		writeMediaCache,
+		clearMediaCache
+	} from '$utils/media';
+	import type { MediaEntry, MediaMeta, MediaSortKey } from '$types/types';
 
 	type Status = 'loading' | 'token' | 'error' | 'ready';
+	type Dim = 'type' | 'topics' | 'year' | 'day' | 'rating' | 'search';
+	type FacetKey = 'types' | 'topics' | 'years' | 'ratings';
 
 	let status = $state<Status>('loading');
 	let tokenInput = $state('');
 	let tokenMessage = $state('');
 	let entries = $state<MediaEntry[]>([]);
 	let isAdmin = $state(false);
+	let stale = $state(false);
 
-	// Filters (all client-side, like the search page)
+	// ─── Tabs, filters & sorting (all client-side) ───
+
+	let activeTab = $state<'done' | 'todo'>('done');
 	let searchTerm = $state('');
 	let selectedTopics = $state<Set<string>>(new Set());
-	let selectedType = $state('');
+	let selectedTypes = $state<Set<string>>(new Set());
+	let selectedYears = $state<Set<number>>(new Set());
+	let selectedDay = $state<string | null>(null);
+	let minRating = $state(0);
+	let sortKey = $state<MediaSortKey>('added');
+	let sortAsc = $state(false);
+	let mobileFiltersOpen = $state(false);
 
-	let filtered = $derived.by(() => {
-		let list = entries;
-		if (selectedType) list = list.filter((e) => e.type === selectedType);
-		if (selectedTopics.size > 0) {
-			list = list.filter((e) => [...selectedTopics].every((t) => e.topics.includes(t)));
+	const SORT_KEYS: MediaSortKey[] = ['added', 'rating', 'title'];
+	const comparators: Record<MediaSortKey, (a: MediaEntry, b: MediaEntry) => number> = {
+		added: (a, b) => a.added_at.localeCompare(b.added_at),
+		rating: (a, b) => (a.rating ?? 0) - (b.rating ?? 0),
+		title: (a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+	};
+
+	let doneEntries = $derived(entries.filter((e) => e.status === 'done'));
+	let todoCount = $derived(entries.length - doneEntries.length);
+	let tabBase = $derived(entries.filter((e) => e.status === activeTab));
+
+	// One predicate per filter dimension; cross-dimension composition is AND.
+	// Types/Years are OR within their facet (an entry has one value), Topics is AND.
+	let predicates = $derived.by(() => {
+		const preds = new Map<Dim, (e: MediaEntry) => boolean>();
+		if (selectedTypes.size) preds.set('type', (e) => selectedTypes.has(e.type));
+		if (selectedTopics.size) {
+			preds.set('topics', (e) => [...selectedTopics].every((t) => e.topics.includes(t)));
 		}
-		if (searchTerm.trim()) {
-			const term = searchTerm.toLowerCase().trim();
-			list = list.filter(
+		if (selectedYears.size) {
+			preds.set('year', (e) => selectedYears.has(new Date(e.added_at).getFullYear()));
+		}
+		if (selectedDay) preds.set('day', (e) => localDateKey(new Date(e.added_at)) === selectedDay);
+		if (minRating > 0) preds.set('rating', (e) => (e.rating ?? 0) >= minRating);
+		const term = searchTerm.toLowerCase().trim();
+		if (term) {
+			preds.set(
+				'search',
 				(e) =>
 					e.title.toLowerCase().includes(term) ||
 					e.author.toLowerCase().includes(term) ||
-					e.note.toLowerCase().includes(term)
+					e.note.toLowerCase().includes(term) ||
+					e.comments.some((c) => c.body.toLowerCase().includes(term))
 			);
 		}
-		return list;
+		return preds;
 	});
 
+	function applyFilters(list: MediaEntry[], except?: Dim): MediaEntry[] {
+		let out = list;
+		for (const [dim, pred] of predicates) if (dim !== except) out = out.filter(pred);
+		return out;
+	}
+
+	let filteredUnsorted = $derived(applyFilters(tabBase));
+	let filtered = $derived(
+		[...filteredUnsorted].sort((a, b) => (sortAsc ? 1 : -1) * comparators[sortKey](a, b))
+	);
+
+	// ─── Facets: counts computed excluding their own dimension (no dead-ends);
+	//     topics are conjunctive so they count over the fully filtered list. ───
+
+	interface FacetRow {
+		value: string;
+		count: number;
+		avg: number | null;
+		selected: boolean;
+	}
+
+	function aggregate(base: MediaEntry[], key: (e: MediaEntry) => string | null) {
+		const m = new Map<string, { count: number; sum: number; rated: number }>();
+		for (const e of base) {
+			const k = key(e);
+			if (k == null) continue;
+			const a = m.get(k) ?? { count: 0, sum: 0, rated: 0 };
+			a.count++;
+			if (e.rating != null) {
+				a.sum += e.rating;
+				a.rated++;
+			}
+			m.set(k, a);
+		}
+		return m;
+	}
+
+	// Stable universes/order from the tab base (never reshuffles as filters change).
 	let allTypes = $derived.by(() => {
 		const counts = new Map<string, number>();
-		for (const e of entries) counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
-		return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+		for (const e of tabBase) counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+		for (const t of selectedTypes) if (!counts.has(t)) counts.set(t, 0);
+		return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([t]) => t);
 	});
 
 	let allTopics = $derived.by(() => {
 		const counts = new Map<string, number>();
-		for (const e of entries) for (const t of e.topics) counts.set(t, (counts.get(t) ?? 0) + 1);
-		return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+		for (const e of tabBase) for (const t of e.topics) counts.set(t, (counts.get(t) ?? 0) + 1);
+		for (const t of selectedTopics) if (!counts.has(t)) counts.set(t, 0);
+		return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([t]) => t);
 	});
 
+	const readYear = (e: MediaEntry) => new Date(e.added_at).getFullYear();
+
+	let allYears = $derived.by(() => {
+		const years = new Set<number>();
+		for (const e of tabBase) years.add(readYear(e));
+		for (const y of selectedYears) years.add(y);
+		return [...years].sort((a, b) => b - a);
+	});
+
+	let typeFacet = $derived.by(() => {
+		const agg = aggregate(applyFilters(tabBase, 'type'), (e) => e.type);
+		return allTypes.map((type): FacetRow => {
+			const a = agg.get(type) ?? { count: 0, sum: 0, rated: 0 };
+			return {
+				value: type,
+				count: a.count,
+				avg: a.rated ? a.sum / a.rated : null,
+				selected: selectedTypes.has(type)
+			};
+		});
+	});
+	let typeMax = $derived(Math.max(1, ...typeFacet.map((r) => r.count)));
+
+	let topicFacet = $derived.by(() => {
+		const counts = new Map<string, number>();
+		for (const e of filteredUnsorted) {
+			for (const t of e.topics) counts.set(t, (counts.get(t) ?? 0) + 1);
+		}
+		return allTopics.map((t) => ({
+			value: t,
+			count: counts.get(t) ?? 0,
+			selected: selectedTopics.has(t)
+		}));
+	});
+
+	let yearFacet = $derived.by(() => {
+		const agg = aggregate(applyFilters(tabBase, 'year'), (e) => String(readYear(e)));
+		return allYears.map((year): FacetRow => {
+			const a = agg.get(String(year)) ?? { count: 0, sum: 0, rated: 0 };
+			return { value: String(year), count: a.count, avg: null, selected: selectedYears.has(year) };
+		});
+	});
+	let yearMax = $derived(Math.max(1, ...yearFacet.map((r) => r.count)));
+
+	let ratingFacet = $derived.by(() => {
+		const base = applyFilters(tabBase, 'rating');
+		return [5, 4, 3, 2, 1].map((r) => ({
+			stars: r,
+			count: base.filter((e) => e.rating === r).length
+		}));
+	});
+	let ratingMax = $derived(Math.max(1, ...ratingFacet.map((r) => r.count)));
+
+	// Chips are packed into rows instead of relying on flex-wrap, so a very long
+	// label (e.g. "software engineering") can't leave the rest of its row empty.
+	let topicsWidth = $state(0);
+	let packedTopics = $derived.by(() => {
+		const capacity = (topicsWidth || 212) - 6;
+		// Monospace chips: width is exactly linear in glyph count (measured fit).
+		const CHAR = 7.364;
+		const CHROME = 12.1;
+		const width = (c: { value: string; count: number }) =>
+			CHAR * (c.value.length + 1 + 0.8 * String(c.count).length) + CHROME;
+		// Longest chips first: fills rows evenly instead of leaving a long label
+		// alone on its own line (counts stay visible on every chip).
+		const byWidth = [...topicFacet].sort((a, b) => width(b) - width(a));
+		return packRows(byWidth, capacity, width);
+	});
+
+	const TOPIC_ROWS = 5;
+	let topicsExpanded = $state(false);
+	let visibleTopicRows = $derived(
+		topicsExpanded ? packedTopics : packedTopics.slice(0, TOPIC_ROWS)
+	);
+	let hiddenTopicCount = $derived(
+		packedTopics.slice(TOPIC_ROWS).reduce((n, row) => n + row.length, 0)
+	);
+
+	let overallAvg = $derived.by(() => {
+		const rated = tabBase.filter((e) => e.rating != null);
+		return rated.length ? rated.reduce((s, e) => s + (e.rating ?? 0), 0) / rated.length : null;
+	});
+	let thisYearCount = $derived(
+		tabBase.filter((e) => readYear(e) === new Date().getFullYear()).length
+	);
+
+	let activeFilterCount = $derived(
+		selectedTypes.size +
+			selectedTopics.size +
+			selectedYears.size +
+			(selectedDay ? 1 : 0) +
+			(minRating > 0 ? 1 : 0)
+	);
+	let hasFilters = $derived(Boolean(searchTerm) || activeFilterCount > 0);
+
+	// ─── Loading, auth & cache (stale-while-revalidate) ───
+
+	let mutationVersion = 0;
+
+	const currentToken = () => localStorage.getItem(MEDIA_TOKEN_KEY) ?? '';
+
+	function hydrate(raw: MediaEntry[]): MediaEntry[] {
+		return raw.map((e) => ({ ...e, comments: e.comments ?? [], status: e.status ?? 'done' }));
+	}
+
 	onMount(() => {
-		const token = localStorage.getItem(MEDIA_TOKEN_KEY);
-		if (token) load(token);
-		else status = 'token';
+		const token = currentToken();
+		if (!token) {
+			status = 'token';
+			return;
+		}
+		const cached = readMediaCache(token);
+		if (cached) {
+			entries = hydrate(cached.entries as MediaEntry[]);
+			isAdmin = cached.role === 'admin';
+			formOpen = isAdmin;
+			status = 'ready';
+			revalidate(token);
+		} else {
+			load(token);
+		}
+	});
+
+	// Persist the working set after any change (mutations, revalidation, first load).
+	$effect(() => {
+		if (status !== 'ready') return;
+		writeMediaCache($state.snapshot(entries), isAdmin ? 'admin' : 'reader', currentToken());
 	});
 
 	async function load(token: string) {
@@ -66,6 +274,7 @@
 		}
 		if (response.status === 401 || response.status === 403) {
 			localStorage.removeItem(MEDIA_TOKEN_KEY);
+			clearMediaCache();
 			tokenMessage = 'Invalid token, try again';
 			status = 'token';
 			return;
@@ -76,15 +285,55 @@
 		}
 		const data = await response.json();
 		localStorage.setItem(MEDIA_TOKEN_KEY, token);
-		entries = data.entries;
+		entries = hydrate(data.entries);
 		isAdmin = data.role === 'admin';
+		formOpen = isAdmin;
 		status = 'ready';
+	}
+
+	async function revalidate(token: string) {
+		const version = mutationVersion;
+		let response: Response;
+		try {
+			response = await fetch(`${MEDIA_API}/entries`, {
+				headers: { Authorization: `Bearer ${token}` }
+			});
+		} catch {
+			stale = true;
+			return;
+		}
+		if (response.status === 401 || response.status === 403) {
+			localStorage.removeItem(MEDIA_TOKEN_KEY);
+			clearMediaCache();
+			entries = [];
+			isAdmin = false;
+			tokenMessage = 'Token expired, enter it again';
+			status = 'token';
+			return;
+		}
+		if (!response.ok) {
+			stale = true;
+			return;
+		}
+		const data = await response.json();
+		// A mutation landed while this fetch was in flight: its payload is older
+		// than local state, discard it (next visit converges).
+		if (mutationVersion !== version) return;
+		entries = hydrate(data.entries);
+		isAdmin = data.role === 'admin';
+		stale = false;
 	}
 
 	function submitToken(event: SubmitEvent) {
 		event.preventDefault();
 		if (tokenInput.trim()) load(tokenInput.trim());
 	}
+
+	function authHeaders(): Record<string, string> {
+		return { Authorization: `Bearer ${currentToken()}` };
+	}
+
+	// ─── Filter actions ───
 
 	function toggleTopic(topic: string) {
 		const next = new Set(selectedTopics);
@@ -93,149 +342,190 @@
 		selectedTopics = next;
 	}
 
+	function toggleType(type: string) {
+		const next = new Set(selectedTypes);
+		if (next.has(type)) next.delete(type);
+		else next.add(type);
+		selectedTypes = next;
+	}
+
+	function toggleYear(year: number) {
+		const next = new Set(selectedYears);
+		if (next.has(year)) next.delete(year);
+		else next.add(year);
+		selectedYears = next;
+	}
+
+	function setSort(key: MediaSortKey) {
+		if (sortKey === key) sortAsc = !sortAsc;
+		else {
+			sortKey = key;
+			sortAsc = false;
+		}
+	}
+
 	function clearFilters() {
 		searchTerm = '';
-		selectedType = '';
+		selectedTypes = new Set();
+		selectedYears = new Set();
+		selectedDay = null;
+		minRating = 0;
 		selectedTopics = new Set();
 	}
 
-	function formatDate(iso: string) {
-		return new Date(iso).toLocaleDateString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric'
-		});
-	}
+	// ─── Edit in place ───
 
-	function authHeaders(): Record<string, string> {
-		return { Authorization: `Bearer ${localStorage.getItem(MEDIA_TOKEN_KEY) ?? ''}` };
-	}
+	let formOpen = $state(false);
+	let editing = $state<MediaEntry | null>(null);
+	let panelsOpen = $state({ types: true, topics: true, years: true, ratings: true });
 
-	// ─── Add panel (admin only) ───
-
-	let showForm = $state(false);
-	let editingId = $state<string | null>(null);
-	let formError = $state('');
-	let fetchingMeta = $state(false);
-	let saving = $state(false);
-	let form = $state({
-		url: '',
-		title: '',
-		type: 'article',
-		author: '',
-		year: new Date().getFullYear(),
-		topics: '',
-		rating: 0,
-		note: ''
+	// If filters/sort/tab hide the entry being edited, pin it on top so the
+	// form (and any unsaved input) survives — keyed each preserves the instance.
+	let displayList = $derived.by(() => {
+		if (editing && !filtered.some((e) => e.id === editing!.id)) return [editing, ...filtered];
+		return filtered;
 	});
+	let editingPinned = $derived(editing != null && !filtered.some((e) => e.id === editing!.id));
 
-	function resetForm() {
-		editingId = null;
-		formError = '';
-		form = {
-			url: '',
-			title: '',
-			type: form.type,
-			author: '',
-			year: new Date().getFullYear(),
-			topics: '',
-			rating: 0,
-			note: ''
-		};
+	async function startEdit(entry: MediaEntry) {
+		editing = entry;
+		// The form is taller than the row it replaces; browsers' scroll anchoring
+		// can jump the viewport. Bring the form back with minimal scrolling.
+		await tick();
+		document.getElementById(`entry-${entry.id}`)?.scrollIntoView({ block: 'nearest' });
 	}
 
-	function startEdit(entry: MediaEntry) {
-		editingId = entry.id;
-		formError = '';
-		form = {
-			url: entry.url,
-			title: entry.title,
-			type: entry.type,
-			author: entry.author,
-			year: entry.year ?? new Date().getFullYear(),
-			topics: entry.topics.join(', '),
-			rating: entry.rating ?? 0,
-			note: entry.note
-		};
-		showForm = true;
-		window.scrollTo({ top: 0, behavior: 'smooth' });
+	function cancelEdit() {
+		editing = null;
 	}
 
-	async function fetchMeta() {
-		if (!form.url.trim()) return;
-		fetchingMeta = true;
-		formError = '';
-		try {
-			const response = await fetch(`${MEDIA_API}/meta?url=${encodeURIComponent(form.url.trim())}`, {
-				headers: authHeaders()
-			});
-			const data = await response.json();
-			if (!response.ok) {
-				formError = data.error ?? 'metadata fetch failed';
-			} else {
-				if (data.title) form.title = data.title;
-				if (data.author) form.author = data.author;
-				if (data.url) form.url = data.url;
-				if (data.warning) formError = data.warning;
-			}
-		} catch {
-			formError = 'metadata fetch failed';
-		}
-		fetchingMeta = false;
+	async function editExisting(dup: MediaEntry) {
+		editing = dup;
+		await tick();
+		document
+			.getElementById(`entry-${dup.id}`)
+			?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}
 
-	async function submitEntry(event: SubmitEvent) {
-		event.preventDefault();
-		saving = true;
-		formError = '';
-		const payload = {
-			title: form.title,
-			type: form.type,
-			author: form.author,
-			url: form.url,
-			year: form.year || null,
-			topics: form.topics
-				.split(',')
-				.map((t) => t.trim())
-				.filter(Boolean),
-			rating: form.rating || null,
-			note: form.note
-		};
+	// ─── URL identity ───
+
+	let urlIndex = $derived.by(() => {
+		const m = new Map<string, MediaEntry>();
+		for (const e of entries) if (e.url) m.set(normalizeUrl(e.url), e);
+		return m;
+	});
+	const findByUrl = (url: string) => urlIndex.get(normalizeUrl(url)) ?? null;
+
+	// ─── Admin actions (passed down to components) ───
+
+	async function saveEntry(payload: Record<string, unknown>): Promise<string | null> {
 		try {
 			const response = await fetch(
-				editingId ? `${MEDIA_API}/entries/${editingId}` : `${MEDIA_API}/entries`,
+				editing ? `${MEDIA_API}/entries/${editing.id}` : `${MEDIA_API}/entries`,
 				{
-					method: editingId ? 'PUT' : 'POST',
+					method: editing ? 'PUT' : 'POST',
 					headers: { ...authHeaders(), 'Content-Type': 'application/json' },
 					body: JSON.stringify(payload)
 				}
 			);
 			const data = await response.json();
-			if (!response.ok) {
-				formError = data.error ?? 'save failed';
-			} else {
-				entries = editingId
-					? entries.map((e) => (e.id === editingId ? data : e))
-					: [data, ...entries];
-				resetForm();
-				showForm = false;
-			}
+			if (!response.ok) return data.error ?? 'save failed';
+			const saved = hydrate([data])[0];
+			mutationVersion++;
+			entries = editing ? entries.map((e) => (e.id === saved.id ? saved : e)) : [saved, ...entries];
+			editing = null;
+			return null;
 		} catch {
-			formError = 'save failed (network)';
+			return 'save failed (network)';
 		}
-		saving = false;
 	}
 
-	async function deleteEntry(entry: MediaEntry) {
-		if (!confirm(`Delete "${entry.title}"?`)) return;
+	async function markRead(entry: MediaEntry): Promise<void> {
+		try {
+			const response = await fetch(`${MEDIA_API}/entries/${entry.id}`, {
+				method: 'PUT',
+				headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					title: entry.title,
+					type: entry.type,
+					author: entry.author,
+					url: entry.url,
+					year: entry.year,
+					topics: entry.topics,
+					rating: entry.rating,
+					note: entry.note,
+					status: 'done',
+					added_at: new Date().toISOString()
+				})
+			});
+			if (!response.ok) return;
+			const saved = hydrate([await response.json()])[0];
+			mutationVersion++;
+			entries = entries.map((e) => (e.id === saved.id ? saved : e));
+		} catch {
+			// row keeps its todo state; user can retry
+		}
+	}
+
+	async function fetchMetaFor(url: string): Promise<MediaMeta | null> {
+		try {
+			const response = await fetch(`${MEDIA_API}/meta?url=${encodeURIComponent(url)}`, {
+				headers: authHeaders()
+			});
+			if (!response.ok) return null;
+			return await response.json();
+		} catch {
+			return null;
+		}
+	}
+
+	async function deleteEntry(entry: MediaEntry): Promise<boolean> {
 		try {
 			const response = await fetch(`${MEDIA_API}/entries/${entry.id}`, {
 				method: 'DELETE',
 				headers: authHeaders()
 			});
-			if (response.ok) entries = entries.filter((e) => e.id !== entry.id);
+			if (!response.ok) return false;
+			mutationVersion++;
+			entries = entries.filter((e) => e.id !== entry.id);
+			return true;
 		} catch {
-			// keep the entry; nothing to do
+			return false;
+		}
+	}
+
+	async function addComment(entry: MediaEntry, body: string): Promise<string | null> {
+		try {
+			const response = await fetch(`${MEDIA_API}/entries/${entry.id}/comments`, {
+				method: 'POST',
+				headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ body })
+			});
+			const data = await response.json();
+			if (response.status !== 201) return data.error ?? 'comment failed';
+			mutationVersion++;
+			entries = entries.map((e) =>
+				e.id === entry.id ? { ...e, comments: [...e.comments, data] } : e
+			);
+			return null;
+		} catch {
+			return 'comment failed (network)';
+		}
+	}
+
+	async function deleteComment(entry: MediaEntry, cid: string): Promise<void> {
+		try {
+			const response = await fetch(`${MEDIA_API}/entries/${entry.id}/comments/${cid}`, {
+				method: 'DELETE',
+				headers: authHeaders()
+			});
+			if (!response.ok) return;
+			mutationVersion++;
+			entries = entries.map((e) =>
+				e.id === entry.id ? { ...e, comments: e.comments.filter((c) => c.id !== cid) } : e
+			);
+		} catch {
+			// entry keeps the comment; user can retry
 		}
 	}
 </script>
@@ -245,14 +535,279 @@
 	<meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto max-w-[960px] px-4 pt-10 pb-16">
+{#snippet facetBar(count: number, max: number)}
+	<span
+		class="h-[3px] min-w-[2px] rounded-full"
+		style="width: {Math.round(
+			(count / max) * 100
+		)}%; background: var(--color-accent); opacity: 0.75;"
+	></span>
+{/snippet}
+
+{#snippet sectionHeader(key: FacetKey, label: string, active: number)}
+	<button
+		onclick={() => (panelsOpen[key] = !panelsOpen[key])}
+		class="flex w-full cursor-pointer items-center gap-2 px-2.5 py-1.5"
+		style="background: none; border: none;"
+	>
+		<ToggleDiamond open={panelsOpen[key]} tone={active > 0 ? 'accent' : 'muted'} />
+		<span
+			class="font-mono text-[0.62rem] tracking-[0.12em] uppercase"
+			style="color: var(--color-text-muted);"
+		>
+			{label}
+		</span>
+		{#if active > 0}
+			<span class="font-mono text-[0.6rem]" style="color: var(--color-accent);">{active}</span>
+		{/if}
+	</button>
+{/snippet}
+
+{#snippet facetRow(
+	label: string,
+	count: number,
+	max: number,
+	selected: boolean,
+	onclick: () => void,
+	labelClass: string,
+	avg: number | null = null
+)}
+	<button
+		{onclick}
+		class="flex cursor-pointer items-center gap-2 px-2.5 py-[3px] text-left transition-colors duration-150 hover:text-[--color-accent]"
+		style="color: {selected ? 'var(--color-accent)' : 'var(--color-text-muted)'};
+			background: none; border: none;
+			font-weight: {selected ? '700' : '400'};
+			opacity: {count === 0 && !selected ? 0.35 : 1};"
+	>
+		<span class="w-[58px] shrink-0 truncate {labelClass}">{label}</span>
+		<span class="flex h-[3px] min-w-0 flex-1 rounded-full" style="background: var(--color-border);">
+			{@render facetBar(count, max)}
+		</span>
+		<span class="w-[18px] shrink-0 text-right font-mono text-[0.6rem]" style="opacity: 0.6;">
+			{count}
+		</span>
+		<span
+			class="w-[26px] shrink-0 font-mono text-[0.6rem]"
+			style="color: var(--color-accent); opacity: 0.85;"
+		>
+			{avg != null ? `◆${avg.toFixed(1)}` : ''}
+		</span>
+	</button>
+{/snippet}
+
+{#snippet controlStrip()}
+	<div
+		class="flex flex-wrap items-center gap-x-3 gap-y-1 px-2.5 py-1 font-mono text-[0.68rem]"
+		style="color: var(--color-text-muted);"
+	>
+		<span class="flex items-center gap-2">
+			{#each [['done', 'log', doneEntries.length], ['todo', 'to read', todoCount]] as [tab, label, count] (tab)}
+				<button
+					onclick={() => (activeTab = tab as 'done' | 'todo')}
+					aria-label="show {label}"
+					aria-pressed={activeTab === tab}
+					class="cursor-pointer py-0.5 transition-colors duration-150"
+					style="background: none; border: none;
+									color: {activeTab === tab ? 'var(--color-accent)' : 'var(--color-text-muted)'};
+									font-weight: {activeTab === tab ? '700' : '400'};"
+				>
+					{activeTab === tab ? '◆' : '◇'}
+					{label}
+					<span style="opacity: 0.55;">{count}</span>
+				</button>
+			{/each}
+		</span>
+
+		{#if hasFilters}
+			<span class="min-w-0 truncate" style="opacity: 0.8;">
+				→ {filtered.length}
+				{#if selectedTypes.size > 0}<span> · {[...selectedTypes].join(' ')}</span>{/if}
+				{#if selectedYears.size > 0}<span> · {[...selectedYears].join(' ')}</span>{/if}
+				{#if selectedDay}<span> · {selectedDay}</span>{/if}
+				{#if selectedTopics.size > 0}
+					<span> · {[...selectedTopics].map((t) => `#${t}`).join(' ')}</span>
+				{/if}
+			</span>
+		{/if}
+
+		{#if stale}
+			<button
+				onclick={() => {
+					stale = false;
+					revalidate(currentToken());
+				}}
+				class="cursor-pointer underline"
+				style="background: none; border: none; color: #b0413e;"
+			>
+				cached · retry
+			</button>
+		{/if}
+
+		<span class="ml-auto flex items-center gap-1">
+			{#each SORT_KEYS as key (key)}
+				<button
+					onclick={() => setSort(key)}
+					class="cursor-pointer px-1 py-0.5 transition-colors duration-150"
+					style="background: none; border: none; color: {sortKey === key
+						? 'var(--color-accent)'
+						: 'var(--color-text-muted)'}; font-weight: {sortKey === key ? '700' : '400'};"
+				>
+					{key}{sortKey === key ? (sortAsc ? ' ↑' : ' ↓') : ''}
+				</button>
+			{/each}
+			<span class="flex items-center" title="minimum rating">
+				{#each [1, 2, 3, 4, 5] as star (star)}
+					<button
+						aria-label="min rating {star}"
+						onclick={() => (minRating = minRating === star ? 0 : star)}
+						class="flex h-5 w-[15px] cursor-pointer items-center justify-center text-[0.68rem]"
+						style="background: none; border: none; color: {minRating >= star
+							? 'var(--color-accent)'
+							: 'var(--color-border-strong)'};"
+					>
+						◆
+					</button>
+				{/each}
+			</span>
+		</span>
+	</div>
+{/snippet}
+
+{#snippet facetPanels()}
+	<div class="rounded" style="border: 1px solid var(--color-border);">
+		<!-- Summary -->
+		<div
+			class="flex flex-wrap items-baseline gap-x-2 px-2.5 py-2 font-mono text-[0.6rem]"
+			style="border-bottom: 1px solid var(--color-border); color: var(--color-text-muted);"
+		>
+			<span style="color: var(--color-text);">{tabBase.length}</span>
+			<span style="opacity: 0.6;">entries</span>
+			{#if overallAvg != null}
+				<span style="opacity: 0.4;">·</span>
+				<span style="color: var(--color-accent);">◆{overallAvg.toFixed(1)}</span>
+			{/if}
+			{#if thisYearCount > 0}
+				<span style="opacity: 0.4;">·</span>
+				<span style="color: var(--color-text);">{thisYearCount}</span>
+				<span style="opacity: 0.6;">in {new Date().getFullYear()}</span>
+			{/if}
+		</div>
+
+		<!-- Types -->
+		<div style="border-bottom: 1px solid var(--color-border);">
+			{@render sectionHeader('types', 'Types', selectedTypes.size)}
+			{#if panelsOpen.types}
+				<div class="flex flex-col pb-1.5" transition:slide={{ duration: 160 }}>
+					{#each typeFacet as row (row.value)}
+						{@render facetRow(
+							row.value,
+							row.count,
+							typeMax,
+							row.selected,
+							() => toggleType(row.value),
+							'font-serif text-[0.75rem] [font-variant:small-caps]',
+							row.avg
+						)}
+					{/each}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Topics: chips packed into evenly filled rows -->
+		{#if topicFacet.length > 0}
+			<div style="border-bottom: 1px solid var(--color-border);">
+				{@render sectionHeader('topics', 'Topics', selectedTopics.size)}
+				{#if panelsOpen.topics}
+					<div class="px-2.5 pb-2" transition:slide={{ duration: 160 }}>
+						<div bind:clientWidth={topicsWidth} class="flex flex-col gap-1">
+							{#each visibleTopicRows as row, i (i)}
+								<div class="flex gap-1">
+									{#each row as chip (chip.value)}
+										<button
+											onclick={() => toggleTopic(chip.value)}
+											class="shrink-0 cursor-pointer rounded-sm border font-mono text-[0.65rem] whitespace-nowrap transition-all duration-150"
+											style="
+												padding: 1px 5px;
+												letter-spacing: 0.03em;
+												border-color: {chip.selected ? '#D4A017' : 'var(--color-border)'};
+												color: {chip.selected ? '#1A1A1A' : 'var(--color-text-muted)'};
+												background: {chip.selected ? '#D4A017' : 'transparent'};
+												font-weight: {chip.selected ? '700' : '400'};
+												opacity: {chip.count === 0 && !chip.selected ? 0.35 : 1};
+											"
+										>
+											{chip.value}
+											<span style="opacity: 0.5; font-size: 0.8em;">{chip.count}</span>
+										</button>
+									{/each}
+								</div>
+							{/each}
+						</div>
+						{#if packedTopics.length > TOPIC_ROWS}
+							<button
+								onclick={() => (topicsExpanded = !topicsExpanded)}
+								class="mt-1 cursor-pointer font-mono text-[0.6rem] transition-colors duration-150 hover:text-[--color-accent]"
+								style="background: none; border: none; color: var(--color-text-muted);"
+							>
+								{topicsExpanded ? '◆ less' : `◇ ${hiddenTopicCount} more`}
+							</button>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Years -->
+		{#if yearFacet.length > 0}
+			<div style="border-bottom: 1px solid var(--color-border);">
+				{@render sectionHeader('years', 'Years', selectedYears.size)}
+				{#if panelsOpen.years}
+					<div class="flex flex-col pb-1.5" transition:slide={{ duration: 160 }}>
+						{#each yearFacet as row (row.value)}
+							{@render facetRow(
+								row.value,
+								row.count,
+								yearMax,
+								row.selected,
+								() => toggleYear(Number(row.value)),
+								'font-mono text-[0.7rem]'
+							)}
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Ratings -->
+		<div>
+			{@render sectionHeader('ratings', 'Ratings', minRating > 0 ? 1 : 0)}
+			{#if panelsOpen.ratings}
+				<div class="flex flex-col pb-1.5" transition:slide={{ duration: 160 }}>
+					{#each ratingFacet as row (row.stars)}
+						{@render facetRow(
+							'◆'.repeat(row.stars),
+							row.count,
+							ratingMax,
+							minRating === row.stars,
+							() => (minRating = minRating === row.stars ? 0 : row.stars),
+							'text-[0.62rem] tracking-[0.12em]'
+						)}
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+{/snippet}
+
+<div class="mx-auto max-w-[960px] px-4 pt-6 pb-16">
 	<h1
 		class="mb-2 text-center font-serif text-xl md:text-2xl"
 		style="font-variant: small-caps; letter-spacing: 0.1em; font-weight: 400; color: var(--color-text);"
 	>
 		Media Log
 	</h1>
-	<div class="separator mb-8"><span class="separator-glyph">◆</span></div>
+	<div class="separator mb-5"><span class="separator-glyph">◆</span></div>
 
 	{#if status === 'loading'}
 		<p class="py-12 text-center font-mono text-xs" style="color: var(--color-text-muted);">
@@ -273,7 +828,7 @@
 						type="password"
 						placeholder="access token"
 						autocomplete="off"
-						class="flex-1 rounded px-3 py-2 font-mono text-sm outline-none"
+						class="min-w-0 flex-1 rounded px-3 py-2 font-mono text-sm outline-none"
 						style="border: 1px solid var(--color-border-strong); background: transparent; color: var(--color-text);"
 					/>
 					<button
@@ -295,7 +850,7 @@
 				Could not reach the media API
 			</p>
 			<button
-				onclick={() => load(localStorage.getItem(MEDIA_TOKEN_KEY) ?? '')}
+				onclick={() => load(currentToken())}
 				class="mt-2 cursor-pointer font-mono text-xs hover:text-[--color-accent]"
 				style="color: var(--color-text-muted); background: none; border: none;"
 			>
@@ -303,341 +858,164 @@
 			</button>
 		</div>
 	{:else}
+		<Heatmap
+			entries={doneEntries.map((e) => ({ title: e.title, added_at: e.added_at }))}
+			selected={selectedDay}
+			onselect={(day) => (selectedDay = day)}
+		/>
+
 		<div class="flex flex-col gap-6 md:flex-row">
 			<!-- Main column -->
 			<div class="min-w-0 flex-1">
-				<!-- Search + add row -->
-				<div class="mb-4 flex items-center gap-2">
+				<!-- Add panel: open by default for admin, minimizable -->
+				{#if isAdmin}
 					<div
-						class="flex flex-1 items-center gap-2 rounded px-3 py-2"
+						class="mb-3 rounded"
 						style="border: 1px solid var(--color-border); background: var(--color-surface);"
+					>
+						<button
+							onclick={() => (formOpen = !formOpen)}
+							class="flex w-full cursor-pointer items-center gap-2 px-2.5 py-1.5"
+							style="background: none; border: none;"
+						>
+							<ToggleDiamond open={formOpen} />
+							<span
+								class="font-mono text-[0.62rem] tracking-[0.12em] uppercase"
+								style="color: var(--color-text-muted);"
+							>
+								add to {activeTab === 'todo' ? 'backlog' : 'log'}
+							</span>
+						</button>
+						{#if formOpen}
+							<div
+								style="border-top: 1px solid var(--color-border);"
+								transition:slide={{ duration: 200, easing: cubicOut }}
+							>
+								<!-- keyed on the tab so a new entry lands in the visible list -->
+								{#key activeTab}
+									<MediaForm
+										entry={null}
+										defaultStatus={activeTab}
+										bare
+										onsave={saveEntry}
+										oncancel={() => (formOpen = false)}
+										onfetchmeta={fetchMetaFor}
+										{findByUrl}
+										oneditexisting={editExisting}
+									/>
+								{/key}
+							</div>
+						{/if}
+					</div>
+				{/if}
+
+				<!-- Search + controls: one box -->
+				<div class="mb-3 rounded" style="border: 1px solid var(--color-border);">
+					<div
+						class="flex min-w-0 items-center gap-2 px-2.5 py-1.5"
+						style="border-bottom: 1px solid var(--color-border);"
 					>
 						<input
 							bind:value={searchTerm}
 							type="text"
-							placeholder="Filter by title, author, note..."
-							class="flex-1 border-none bg-transparent text-sm outline-none"
+							placeholder="filter by title, author, note, comment…"
+							class="min-w-0 flex-1 border-none bg-transparent text-[0.85rem] outline-none"
 							style="color: var(--color-text); font-family: var(--font-body);"
 						/>
-						{#if searchTerm || selectedType || selectedTopics.size > 0}
+						{#if hasFilters}
 							<button
 								onclick={clearFilters}
-								class="cursor-pointer font-mono text-xs transition-colors duration-200 hover:text-[--color-accent]"
+								class="shrink-0 cursor-pointer font-mono text-[0.65rem] transition-colors duration-200 hover:text-[--color-accent]"
 								style="color: var(--color-text-muted); background: none; border: none;"
 								>clear</button
 							>
 						{/if}
 					</div>
-					{#if isAdmin}
-						<button
-							onclick={() => {
-								if (showForm) resetForm();
-								showForm = !showForm;
-							}}
-							class="cursor-pointer rounded px-3 py-2 font-mono text-xs transition-colors duration-200"
-							style="border: 1px solid {showForm
-								? 'var(--color-accent)'
-								: 'var(--color-border-strong)'}; color: {showForm
-								? 'var(--color-accent)'
-								: 'var(--color-text-muted)'}; background: var(--color-surface);"
-						>
-							{showForm ? 'close' : '+ add'}
-						</button>
-					{/if}
+					{@render controlStrip()}
 				</div>
 
-				<!-- Add panel -->
-				{#if isAdmin && showForm}
-					<form
-						onsubmit={submitEntry}
-						class="mb-6 flex flex-col gap-2.5 rounded p-4"
-						style="border: 1px solid var(--color-border-strong); background: var(--color-surface);"
+				<!-- Mobile filters (same panels as the sidebar) -->
+				<div class="mb-3 md:hidden">
+					<button
+						onclick={() => (mobileFiltersOpen = !mobileFiltersOpen)}
+						class="flex w-full cursor-pointer items-center gap-2 rounded px-2.5 py-1.5"
+						style="border: 1px solid var(--color-border);"
 					>
-						<div class="flex items-center gap-2">
-							<input
-								bind:value={form.url}
-								type="url"
-								placeholder="https://... (optional)"
-								class="media-input flex-1"
-							/>
-							<button
-								type="button"
-								onclick={fetchMeta}
-								disabled={fetchingMeta || !form.url.trim()}
-								class="cursor-pointer rounded px-3 py-1.5 font-mono text-[0.65rem] transition-colors duration-200 hover:text-[--color-accent] disabled:cursor-default disabled:opacity-40"
-								style="border: 1px solid var(--color-border-strong); color: var(--color-text-muted); background: none;"
-							>
-								{fetchingMeta ? 'fetching...' : 'fetch metadata'}
-							</button>
+						<ToggleDiamond open={mobileFiltersOpen} />
+						<span
+							class="font-mono text-[0.62rem] tracking-[0.12em] uppercase"
+							style="color: var(--color-text-muted);"
+						>
+							filters{activeFilterCount > 0 ? ` · ${activeFilterCount}` : ''}
+						</span>
+					</button>
+					{#if mobileFiltersOpen}
+						<div class="mt-2" transition:slide={{ duration: 200, easing: cubicOut }}>
+							{@render facetPanels()}
 						</div>
-						<input bind:value={form.title} required placeholder="Title *" class="media-input" />
-						<div class="flex flex-col gap-2.5 sm:flex-row">
-							<input
-								bind:value={form.type}
-								list="media-types"
-								placeholder="type"
-								class="media-input sm:w-[130px]"
-							/>
-							<datalist id="media-types">
-								{#each ['article', 'book', 'paper', 'film', 'video', 'podcast'] as t}
-									<option value={t}></option>
-								{/each}
-							</datalist>
-							<input bind:value={form.author} placeholder="Author" class="media-input flex-1" />
-							<input
-								bind:value={form.year}
-								type="number"
-								placeholder="year"
-								class="media-input sm:w-[90px]"
-							/>
-						</div>
-						<input
-							bind:value={form.topics}
-							placeholder="topics, comma, separated"
-							class="media-input"
-						/>
-						<div class="flex items-center gap-2">
-							<span class="font-mono text-[0.65rem]" style="color: var(--color-text-muted);"
-								>rating</span
-							>
-							{#each [1, 2, 3, 4, 5] as star}
-								<button
-									type="button"
-									onclick={() => (form.rating = form.rating === star ? 0 : star)}
-									class="cursor-pointer text-sm"
-									style="background: none; border: none; color: {form.rating >= star
-										? 'var(--color-accent)'
-										: 'var(--color-border-strong)'};"
-								>
-									◆
-								</button>
-							{/each}
-						</div>
-						<textarea bind:value={form.note} placeholder="Note" rows="2" class="media-input"
-						></textarea>
-						{#if formError}
-							<p class="font-mono text-xs" style="color: #b0413e;">{formError}</p>
-						{/if}
-						<div class="flex items-center justify-end gap-2">
-							{#if editingId}
-								<span class="font-mono text-[0.65rem]" style="color: var(--color-text-muted);"
-									>editing entry</span
-								>
-							{/if}
-							<button
-								type="submit"
-								disabled={saving}
-								class="cursor-pointer rounded px-4 py-1.5 font-mono text-xs transition-colors duration-200 disabled:opacity-40"
-								style="border: 1px solid var(--color-accent); color: var(--color-accent); background: none;"
-							>
-								{saving ? 'saving...' : editingId ? 'update' : 'save'}
-							</button>
-						</div>
-					</form>
-				{/if}
-
-				<!-- Count -->
-				<div
-					class="mb-4 rounded-sm px-3 py-1.5 font-mono text-[0.7rem]"
-					style="background: var(--color-surface); color: var(--color-text-muted);"
-				>
-					{filtered.length} entr{filtered.length !== 1 ? 'ies' : 'y'}
-					{#if selectedType}<span>of type {selectedType}</span>{/if}
-					{#if selectedTopics.size > 0}
-						<span>for {[...selectedTopics].map((t) => `#${t}`).join(', ')}</span>
 					{/if}
 				</div>
 
-				<!-- Entries -->
+				<!-- Entries (inline edit swaps the row for the form, in place) -->
 				<div class="flex flex-col">
-					{#each filtered as entry (entry.id)}
-						<div class="group py-3.5" style="border-bottom: 1px solid var(--color-border);">
-							<div class="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
-								<span
-									class="shrink-0 font-mono text-[0.65rem]"
-									style="color: var(--color-text-muted);"
-								>
-									{formatDate(entry.added_at)}
-								</span>
-								{#if entry.url}
-									<a
-										href={entry.url}
-										target="_blank"
-										rel="noreferrer"
-										class="font-serif text-[1rem] transition-colors duration-200 hover:text-[--color-accent]"
-										style="color: var(--color-text);"
-									>
-										{entry.title}
-									</a>
-								{:else}
-									<span class="font-serif text-[1rem]" style="color: var(--color-text);">
-										{entry.title}
-									</span>
-								{/if}
-								{#if entry.author}
-									<span class="text-[0.75rem]" style="color: var(--color-text-muted);">
-										{entry.author}
-									</span>
-								{/if}
-								<span
-									class="hidden font-mono text-[0.55rem] sm:inline"
-									style="color: var(--color-text-muted); opacity: 0.4;"
-								>
-									{entry.type}{entry.year ? ` · ${entry.year}` : ''}
-								</span>
-								{#if entry.rating}
-									<span class="ml-auto shrink-0 text-[0.6rem] tracking-[0.15em]">
-										{#each [1, 2, 3, 4, 5] as star}
-											<span
-												style="color: {entry.rating >= star
-													? 'var(--color-accent)'
-													: 'var(--color-border-strong)'};">◆</span
-											>
-										{/each}
-									</span>
-								{/if}
-								{#if isAdmin}
-									<span class="flex shrink-0 gap-1.5">
-										<button
-											onclick={() => startEdit(entry)}
-											title="edit entry"
-											class="cursor-pointer font-mono text-[0.6rem] opacity-0 transition-opacity duration-200 group-hover:opacity-60 hover:!opacity-100"
-											style="color: var(--color-accent); background: none; border: none;"
+					{#each displayList as entry (entry.id)}
+						<div id="entry-{entry.id}">
+							{#if editing?.id === entry.id}
+								<div class="py-4" style="border-bottom: 1px solid var(--color-border);">
+									{#if editingPinned}
+										<p
+											class="mb-1 font-mono text-[0.65rem]"
+											style="color: var(--color-text-muted);"
 										>
-											✎
-										</button>
-										<button
-											onclick={() => deleteEntry(entry)}
-											title="delete entry"
-											class="cursor-pointer font-mono text-[0.6rem] opacity-0 transition-opacity duration-200 group-hover:opacity-60 hover:!opacity-100"
-											style="color: #b0413e; background: none; border: none;"
-										>
-											✕
-										</button>
-									</span>
-								{/if}
-							</div>
-							{#if entry.note}
-								<p
-									class="mt-0.5 text-[0.8rem] leading-relaxed"
-									style="color: var(--color-text-muted);"
-								>
-									{entry.note}
-								</p>
-							{/if}
-							{#if entry.topics.length > 0}
-								<div class="mt-1.5 flex flex-wrap gap-1">
-									{#each entry.topics as topic (topic)}
-										<TopicPill {topic} disabled onclick={toggleTopic} />
-									{/each}
+											◆ pinned while editing (hidden by current filters)
+										</p>
+									{/if}
+									<MediaForm
+										entry={editing}
+										onsave={saveEntry}
+										oncancel={cancelEdit}
+										onfetchmeta={fetchMetaFor}
+										{findByUrl}
+										oneditexisting={editExisting}
+									/>
 								</div>
+							{:else}
+								<MediaRow
+									{entry}
+									{isAdmin}
+									ontopic={toggleTopic}
+									onedit={startEdit}
+									ondelete={deleteEntry}
+									onaddcomment={addComment}
+									ondeletecomment={deleteComment}
+									onmarkread={markRead}
+								/>
 							{/if}
 						</div>
 					{/each}
 
-					{#if filtered.length === 0}
+					{#if displayList.length === 0}
 						<div class="py-12 text-center">
 							<p class="font-serif text-base" style="color: var(--color-text-muted);">
-								{entries.length === 0 ? 'The log is empty' : 'No matching entries'}
+								{tabBase.length === 0
+									? activeTab === 'todo'
+										? 'The backlog is empty'
+										: 'The log is empty'
+									: 'No matching entries'}
 							</p>
 						</div>
 					{/if}
 				</div>
 			</div>
 
-			<!-- Sidebar: types + topics -->
-			<aside class="w-full shrink-0 md:sticky md:top-16 md:w-[240px] md:self-start">
-				<div
-					class="rounded"
-					style="border: 1px solid var(--color-border); background: var(--color-surface);"
-				>
-					<div class="px-3 py-2" style="border-bottom: 1px solid var(--color-border);">
-						<span
-							class="font-mono text-[0.65rem] tracking-[0.1em] uppercase"
-							style="color: var(--color-text-muted);">Types</span
-						>
-					</div>
-					<div class="flex flex-col gap-0.5 p-2.5">
-						{#each allTypes as [type, count] (type)}
-							<button
-								onclick={() => (selectedType = selectedType === type ? '' : type)}
-								class="flex cursor-pointer items-center justify-between rounded px-2 py-1 text-[0.75rem] transition-colors duration-200 hover:text-[--color-accent]"
-								style="color: {selectedType === type
-									? 'var(--color-accent)'
-									: 'var(--color-text-muted)'}; background: none; border: none; font-weight: {selectedType ===
-								type
-									? '700'
-									: '400'};"
-							>
-								<span class="font-serif" style="font-variant: small-caps;">{type}</span>
-								<span class="font-mono text-[0.6rem]" style="opacity: 0.5;">{count}</span>
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				{#if allTopics.length > 0}
-					<div
-						class="mt-3 rounded"
-						style="border: 1px solid var(--color-border); background: var(--color-surface);"
-					>
-						<div
-							class="flex items-center justify-between px-3 py-2"
-							style="border-bottom: 1px solid var(--color-border);"
-						>
-							<span
-								class="font-mono text-[0.65rem] tracking-[0.1em] uppercase"
-								style="color: var(--color-text-muted);">Topics</span
-							>
-							{#if selectedTopics.size > 0}
-								<button
-									onclick={() => (selectedTopics = new Set())}
-									class="cursor-pointer font-mono text-[0.6rem] transition-colors duration-200 hover:text-[--color-accent]"
-									style="color: var(--color-text-muted); background: none; border: none;"
-								>
-									clear
-								</button>
-							{/if}
-						</div>
-						<div class="flex max-h-[50vh] flex-wrap gap-1 overflow-y-auto p-2.5">
-							{#each allTopics as [topic, count] (topic)}
-								<button
-									onclick={() => toggleTopic(topic)}
-									class="cursor-pointer rounded-sm border font-mono text-[0.65rem] transition-all duration-150"
-									style="
-										padding: 1px 6px;
-										letter-spacing: 0.03em;
-										border-color: {selectedTopics.has(topic) ? '#D4A017' : 'var(--color-border)'};
-										color: {selectedTopics.has(topic) ? '#1A1A1A' : 'var(--color-text-muted)'};
-										background: {selectedTopics.has(topic) ? '#D4A017' : 'transparent'};
-										font-weight: {selectedTopics.has(topic) ? '700' : '400'};
-									"
-								>
-									{topic}
-									<span style="opacity: 0.4; font-size: 0.8em;">{count}</span>
-								</button>
-							{/each}
-						</div>
-					</div>
-				{/if}
+			<!-- Sidebar: faceted filters + stats (desktop) -->
+			<!-- Sticky and internally scrollable: bottom panels stay reachable
+			     without scrolling the whole page. -->
+			<aside
+				class="hidden w-full shrink-0 md:sticky md:top-16 md:block md:max-h-[calc(100vh-5rem)] md:w-[240px] md:self-start md:overflow-y-auto"
+			>
+				{@render facetPanels()}
 			</aside>
 		</div>
 	{/if}
 </div>
-
-<style>
-	.media-input {
-		border: 1px solid var(--color-border);
-		background: transparent;
-		color: var(--color-text);
-		font-family: var(--font-body);
-		font-size: 0.85rem;
-		padding: 6px 10px;
-		border-radius: 4px;
-		outline: none;
-	}
-
-	.media-input:focus {
-		border-color: var(--color-accent);
-	}
-</style>

--- a/worker/migrations/0002_add_comments.sql
+++ b/worker/migrations/0002_add_comments.sql
@@ -1,0 +1,2 @@
+-- Dated comment thread per entry, stored inline as a JSON array.
+ALTER TABLE media ADD COLUMN comments TEXT NOT NULL DEFAULT '[]';

--- a/worker/migrations/0003_add_status.sql
+++ b/worker/migrations/0003_add_status.sql
@@ -1,0 +1,2 @@
+-- Reading state: 'todo' (backlog, not read yet) or 'done' (consumed, in the log).
+ALTER TABLE media ADD COLUMN status TEXT NOT NULL DEFAULT 'done' CHECK (status IN ('todo', 'done'));

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,14 +4,22 @@
  * Auth: Bearer token. READ_TOKEN grants read, ADMIN_TOKEN grants read+write.
  *
  * Routes:
- *   GET    /entries       (read)  -> { role, entries: MediaEntry[] } ordered by added_at desc
- *   POST   /entries       (admin) -> 201 + created entry
- *   PUT    /entries/:id   (admin) -> 200 + updated entry
- *   DELETE /entries/:id   (admin) -> 200 { deleted: id }
- *   GET    /meta?url=...  (admin) -> best-effort { title, author, site, url } extracted from the page
+ *   GET    /entries                     (read)  -> { role, entries: MediaEntry[] } ordered by added_at desc
+ *   POST   /entries                     (admin) -> 201 + created entry
+ *   PUT    /entries/:id                 (admin) -> 200 + updated entry
+ *   DELETE /entries/:id                 (admin) -> 200 { deleted: id }
+ *   POST   /entries/:id/comments        (admin) -> 201 + created comment
+ *   DELETE /entries/:id/comments/:cid   (admin) -> 200 { deleted: cid }
+ *   GET    /meta?url=...                (admin) -> best-effort metadata extracted from the page
  */
 
 type Role = 'admin' | 'reader';
+
+interface MediaComment {
+	id: string;
+	body: string;
+	created_at: string;
+}
 
 interface MediaEntry {
 	id: string;
@@ -23,15 +31,18 @@ interface MediaEntry {
 	topics: string[];
 	rating: number | null;
 	note: string;
+	status: 'todo' | 'done';
 	added_at: string;
 }
+
+const COMMENT_MAX_CHARS = 2000;
 
 const META_MAX_BYTES = 256 * 1024;
 const META_TIMEOUT_MS = 8000;
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
-		const cors = corsHeaders(request, env);
+		const cors = corsHeaders(request);
 
 		if (request.method === 'OPTIONS') {
 			return new Response(null, { status: 204, headers: cors });
@@ -73,13 +84,27 @@ async function route(request: Request, env: Env): Promise<Response> {
 			: updateEntry(request, env, idMatch[1]);
 	}
 
+	const commentsMatch = path.match(/^\/entries\/([\w-]+)\/comments$/);
+	if (commentsMatch && request.method === 'POST') {
+		if (!role) return json({ error: 'unauthorized' }, 401);
+		if (role !== 'admin') return json({ error: 'write access requires the admin token' }, 403);
+		return addComment(request, env, commentsMatch[1]);
+	}
+
+	const commentMatch = path.match(/^\/entries\/([\w-]+)\/comments\/([\w-]+)$/);
+	if (commentMatch && request.method === 'DELETE') {
+		if (!role) return json({ error: 'unauthorized' }, 401);
+		if (role !== 'admin') return json({ error: 'write access requires the admin token' }, 403);
+		return deleteComment(env, commentMatch[1], commentMatch[2]);
+	}
+
 	if (path === '/meta' && request.method === 'GET') {
 		if (!role) return json({ error: 'unauthorized' }, 401);
 		if (role !== 'admin') return json({ error: 'metadata fetch requires the admin token' }, 403);
 		return fetchMeta(url.searchParams.get('url') ?? '');
 	}
 
-	if (['/entries', '/meta'].includes(path) || idMatch) {
+	if (['/entries', '/meta'].includes(path) || idMatch || commentsMatch || commentMatch) {
 		return json({ error: 'method not allowed' }, 405);
 	}
 	return json({ error: 'not found' }, 404);
@@ -109,17 +134,14 @@ async function tokenMatches(provided: string, expected: string | undefined): Pro
 
 // ─── CORS ───
 
-// CORS is not the security boundary here (auth is a Bearer token, no cookies),
-// so *.vercel.app is accepted wholesale to cover production and preview deploys.
-function isAllowedOrigin(origin: string, env: Env): boolean {
-	const allowed = (env.ALLOWED_ORIGINS ?? '').split(',').map((o) => o.trim());
-	return allowed.includes(origin) || /^https:\/\/[\w.-]+\.vercel\.app$/.test(origin);
-}
+// Browser calls are allowed from maellhoutellier.com (and subdomains) plus localhost for dev.
+// Auth is a Bearer token (no cookies), so CORS is a courtesy filter, not the security boundary.
+const ORIGIN_PATTERN = /^(https:\/\/([\w-]+\.)*maellhoutellier\.com|http:\/\/localhost(:\d+)?)$/;
 
-function corsHeaders(request: Request, env: Env): Record<string, string> {
+function corsHeaders(request: Request): Record<string, string> {
 	const origin = request.headers.get('Origin');
 	const headers: Record<string, string> = { Vary: 'Origin' };
-	if (origin && isAllowedOrigin(origin, env)) {
+	if (origin && ORIGIN_PATTERN.test(origin)) {
 		headers['Access-Control-Allow-Origin'] = origin;
 		headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS';
 		headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type';
@@ -132,17 +154,37 @@ function corsHeaders(request: Request, env: Env): Record<string, string> {
 
 async function listEntries(env: Env, role: Role): Promise<Response> {
 	const { results } = await env.DB.prepare('SELECT * FROM media ORDER BY added_at DESC').all();
-	const entries = results.map((row) => ({ ...row, topics: parseTopics(row.topics) }));
+	const entries = results.map(hydrateRow);
 	return json({ role, entries });
 }
 
-function parseTopics(raw: unknown): string[] {
+/** Parse the JSON text columns of a media row into their real shapes. */
+function hydrateRow(row: Record<string, unknown>): Record<string, unknown> {
+	return { ...row, topics: parseTopics(row.topics), comments: parseComments(row.comments) };
+}
+
+function parseJsonArray(raw: unknown): unknown[] {
 	try {
 		const parsed = JSON.parse(String(raw));
-		return Array.isArray(parsed) ? parsed.map(String) : [];
+		return Array.isArray(parsed) ? parsed : [];
 	} catch {
 		return [];
 	}
+}
+
+function parseTopics(raw: unknown): string[] {
+	return parseJsonArray(raw).map(String);
+}
+
+function parseComments(raw: unknown): MediaComment[] {
+	return parseJsonArray(raw).filter(
+		(c): c is MediaComment =>
+			typeof c === 'object' &&
+			c !== null &&
+			typeof (c as MediaComment).id === 'string' &&
+			typeof (c as MediaComment).body === 'string' &&
+			typeof (c as MediaComment).created_at === 'string'
+	);
 }
 
 type EntryFields = Omit<MediaEntry, 'id' | 'added_at'> & { added_at: string | null };
@@ -169,6 +211,11 @@ function parseEntryBody(body: Record<string, unknown>): EntryFields | { error: s
 		? [...new Set(body.topics.map((t) => String(t).trim().toLowerCase()).filter(Boolean))]
 		: [];
 
+	const status = body.status == null ? 'done' : body.status;
+	if (status !== 'todo' && status !== 'done') {
+		return { error: "status must be 'todo' or 'done'" };
+	}
+
 	const added_at =
 		typeof body.added_at === 'string' && !Number.isNaN(Date.parse(body.added_at))
 			? new Date(body.added_at).toISOString()
@@ -183,6 +230,7 @@ function parseEntryBody(body: Record<string, unknown>): EntryFields | { error: s
 		topics,
 		rating,
 		note: typeof body.note === 'string' ? body.note.trim() : '',
+		status,
 		added_at
 	};
 }
@@ -205,8 +253,8 @@ async function createEntry(request: Request, env: Env): Promise<Response> {
 	};
 
 	await env.DB.prepare(
-		`INSERT INTO media (id, title, type, author, url, year, topics, rating, note, added_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`INSERT INTO media (id, title, type, author, url, year, topics, rating, note, status, added_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	)
 		.bind(
 			entry.id,
@@ -218,11 +266,12 @@ async function createEntry(request: Request, env: Env): Promise<Response> {
 			JSON.stringify(entry.topics),
 			entry.rating,
 			entry.note,
+			entry.status,
 			entry.added_at
 		)
 		.run();
 
-	return json(entry, 201);
+	return json({ ...entry, comments: [] }, 201);
 }
 
 async function updateEntry(request: Request, env: Env, id: string): Promise<Response> {
@@ -239,7 +288,7 @@ async function updateEntry(request: Request, env: Env, id: string): Promise<Resp
 	// added_at is preserved unless the payload provides one (COALESCE with null keeps the old value)
 	const result = await env.DB.prepare(
 		`UPDATE media SET title = ?, type = ?, author = ?, url = ?, year = ?, topics = ?, rating = ?, note = ?,
-		 added_at = COALESCE(?, added_at) WHERE id = ?`
+		 status = ?, added_at = COALESCE(?, added_at) WHERE id = ?`
 	)
 		.bind(
 			fields.title,
@@ -250,6 +299,7 @@ async function updateEntry(request: Request, env: Env, id: string): Promise<Resp
 			JSON.stringify(fields.topics),
 			fields.rating,
 			fields.note,
+			fields.status,
 			fields.added_at,
 			id
 		)
@@ -258,7 +308,7 @@ async function updateEntry(request: Request, env: Env, id: string): Promise<Resp
 	if (!result.meta.changes) return json({ error: 'entry not found' }, 404);
 
 	const row = await env.DB.prepare('SELECT * FROM media WHERE id = ?').bind(id).first();
-	return json({ ...row, topics: parseTopics(row?.topics) });
+	return json(hydrateRow(row ?? {}));
 }
 
 async function deleteEntry(env: Env, id: string): Promise<Response> {
@@ -267,10 +317,144 @@ async function deleteEntry(env: Env, id: string): Promise<Response> {
 	return json({ deleted: id });
 }
 
+// ─── Comments ───
+
+async function addComment(request: Request, env: Env, entryId: string): Promise<Response> {
+	let payload: Record<string, unknown>;
+	try {
+		payload = await request.json();
+	} catch {
+		return json({ error: 'invalid JSON body' }, 400);
+	}
+
+	const body = typeof payload.body === 'string' ? payload.body.trim() : '';
+	if (!body) return json({ error: 'comment body is required' }, 400);
+	if (body.length > COMMENT_MAX_CHARS) {
+		return json({ error: `comment too long (max ${COMMENT_MAX_CHARS} chars)` }, 400);
+	}
+
+	const row = await env.DB.prepare('SELECT comments FROM media WHERE id = ?').bind(entryId).first();
+	if (!row) return json({ error: 'entry not found' }, 404);
+
+	const comment: MediaComment = {
+		id: crypto.randomUUID(),
+		body,
+		created_at: new Date().toISOString()
+	};
+	const comments = [...parseComments(row.comments), comment];
+
+	await env.DB.prepare('UPDATE media SET comments = ? WHERE id = ?')
+		.bind(JSON.stringify(comments), entryId)
+		.run();
+
+	return json(comment, 201);
+}
+
+async function deleteComment(env: Env, entryId: string, commentId: string): Promise<Response> {
+	const row = await env.DB.prepare('SELECT comments FROM media WHERE id = ?').bind(entryId).first();
+	if (!row) return json({ error: 'entry not found' }, 404);
+
+	const comments = parseComments(row.comments);
+	const remaining = comments.filter((c) => c.id !== commentId);
+	if (remaining.length === comments.length) return json({ error: 'comment not found' }, 404);
+
+	await env.DB.prepare('UPDATE media SET comments = ? WHERE id = ?')
+		.bind(JSON.stringify(remaining), entryId)
+		.run();
+
+	return json({ deleted: commentId });
+}
+
 // ─── Metadata extraction ───
 
+const NAMED_ENTITIES: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: ' ',
+	ndash: '–',
+	mdash: '—',
+	hellip: '…',
+	lsquo: '‘',
+	rsquo: '’',
+	ldquo: '“',
+	rdquo: '”',
+	eacute: 'é',
+	egrave: 'è',
+	agrave: 'à',
+	ccedil: 'ç',
+	ecirc: 'ê',
+	ocirc: 'ô',
+	auml: 'ä',
+	ouml: 'ö',
+	uuml: 'ü',
+	copy: '©',
+	reg: '®',
+	trade: '™',
+	laquo: '«',
+	raquo: '»',
+	middot: '·',
+	bull: '•',
+	times: '×',
+	deg: '°'
+};
+
+function codePoint(cp: number): string {
+	try {
+		return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : '';
+	} catch {
+		return '';
+	}
+}
+
+/** Numeric forms first so "&amp;#39;" decodes once (to "&#39;"), matching HTML semantics. */
+function decodeEntities(s: string): string {
+	return s
+		.replace(/&#x([0-9a-f]{1,6});/gi, (_, h) => codePoint(parseInt(h, 16)))
+		.replace(/&#(\d{1,7});/g, (_, d) => codePoint(parseInt(d, 10)))
+		.replace(/&([a-zA-Z]+);/g, (m, n) => NAMED_ENTITIES[n.toLowerCase()] ?? m);
+}
+
+function stripTags(s: string): string {
+	return s.replace(/<[^>]*>/g, ' ');
+}
+
+/** Strip markup, decode entities, then strip again (decoding can reintroduce tags
+ *  from escaped markup like "&lt;h1&gt;"), and collapse whitespace. */
+function clean(s: string): string {
+	return stripTags(decodeEntities(stripTags(s)))
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/** Strip a leading "SiteName - " or trailing " - SiteName" only when it matches og:site_name. */
+function stripSiteName(title: string, site: string): string {
+	if (!site) return title;
+	const esc = site.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const suffix = title.match(new RegExp(`^(.{3,})\\s*[|\\-–—·]\\s*${esc}\\s*$`, 'i'));
+	if (suffix) return suffix[1].trim();
+	const prefix = title.match(new RegExp(`^${esc}\\s*[|\\-–—·:]\\s*(.{3,})$`, 'i'));
+	return prefix ? prefix[1].trim() : title;
+}
+
+const hostIs = (host: string, domain: string) => host === domain || host.endsWith('.' + domain);
+
+function detectType(host: string, contentType: string, ogType: string): string {
+	if (contentType.includes('application/pdf')) return 'paper';
+	if (hostIs(host, 'arxiv.org') || hostIs(host, 'openreview.net')) return 'paper';
+	if (hostIs(host, 'youtube.com') || hostIs(host, 'youtu.be') || hostIs(host, 'vimeo.com'))
+		return 'video';
+	if (hostIs(host, 'github.com') || hostIs(host, 'gitlab.com')) return 'repo';
+	if (host.endsWith('.wikipedia.org')) return 'wiki';
+	if (ogType.startsWith('video')) return 'video';
+	if (ogType === 'book') return 'book';
+	return 'article';
+}
+
 async function fetchMeta(target: string): Promise<Response> {
-	const empty = { title: '', author: '', site: '', url: target };
+	const empty = { title: '', author: '', site: '', description: '', published: '', url: target };
 
 	let parsed: URL;
 	try {
@@ -293,18 +477,49 @@ async function fetchMeta(target: string): Promise<Response> {
 			}
 		});
 	} catch {
-		return json({ ...empty, warning: 'could not reach the page' });
-	}
-
-	if (!response.ok || !(response.headers.get('Content-Type') ?? '').includes('text/html')) {
 		return json({
 			...empty,
+			type: detectType(parsed.hostname, '', ''),
+			warning: 'could not reach the page'
+		});
+	}
+
+	const finalUrl = new URL(response.url);
+	const contentType = response.headers.get('Content-Type') ?? '';
+
+	// Direct PDF: best-effort title from the filename, no warning.
+	if (contentType.includes('application/pdf')) {
+		const filename = decodeURIComponent(finalUrl.pathname.split('/').pop() ?? '');
+		return json({
+			...empty,
+			title: filename
+				.replace(/\.pdf$/i, '')
+				.replace(/[_-]+/g, ' ')
+				.trim(),
+			type: 'paper',
+			url: response.url
+		});
+	}
+
+	if (!response.ok || !contentType.includes('text/html')) {
+		return json({
+			...empty,
+			type: detectType(finalUrl.hostname, contentType, ''),
 			url: response.url,
 			warning: `page returned ${response.status} or non-HTML content`
 		});
 	}
 
-	const meta = { titleTag: '', ogTitle: '', author: '', site: '' };
+	const meta = {
+		titleTag: '',
+		ogTitle: '',
+		author: '',
+		site: '',
+		description: '',
+		ogDescription: '',
+		ogType: '',
+		published: ''
+	};
 	const contentOf = (el: Element) => el.getAttribute('content')?.trim() ?? '';
 
 	const rewriter = new HTMLRewriter()
@@ -332,10 +547,29 @@ async function fetchMeta(target: string): Promise<Response> {
 			element(el) {
 				meta.site ||= contentOf(el);
 			}
+		})
+		.on('meta[property="og:description"]', {
+			element(el) {
+				meta.ogDescription ||= contentOf(el);
+			}
+		})
+		.on('meta[name="description"]', {
+			element(el) {
+				meta.description ||= contentOf(el);
+			}
+		})
+		.on('meta[property="og:type"]', {
+			element(el) {
+				meta.ogType ||= contentOf(el);
+			}
+		})
+		.on('meta[property="article:published_time"]', {
+			element(el) {
+				meta.published ||= contentOf(el);
+			}
 		});
 
-	// Handlers run as the transformed stream is pulled; stop early once we have
-	// enough or hit the size cap instead of buffering arbitrary pages.
+	// Handlers run as the transformed stream is pulled; the size cap bounds the work.
 	const body = rewriter.transform(response).body;
 	if (body) {
 		const reader = body.getReader();
@@ -344,15 +578,22 @@ async function fetchMeta(target: string): Promise<Response> {
 			const { done, value } = await reader.read();
 			if (done) break;
 			read += value.byteLength;
-			if (meta.ogTitle && meta.author && meta.site) break;
 		}
 		await reader.cancel().catch(() => {});
 	}
 
+	const site = clean(meta.site);
+	// Wikipedia sends no og:site_name but always suffixes titles with " - Wikipedia".
+	const siteForStrip = site || (finalUrl.hostname.endsWith('.wikipedia.org') ? 'Wikipedia' : '');
+	const title = stripSiteName(clean(meta.ogTitle || meta.titleTag), siteForStrip);
+
 	return json({
-		title: (meta.ogTitle || meta.titleTag).trim(),
-		author: meta.author,
-		site: meta.site,
+		title,
+		author: clean(meta.author),
+		site,
+		description: clean(meta.ogDescription || meta.description).slice(0, 500),
+		published: meta.published,
+		type: detectType(finalUrl.hostname, contentType, meta.ogType.toLowerCase()),
 		url: response.url
 	});
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -6,11 +6,6 @@
 	"observability": {
 		"enabled": true
 	},
-	"vars": {
-		// Extra origins allowed to call the API from a browser (comma-separated).
-		// https://*.vercel.app is always allowed; add a custom domain here if the site gets one.
-		"ALLOWED_ORIGINS": "http://localhost:3000,http://localhost:3001,http://localhost:5173"
-	},
 	"d1_databases": [
 		{
 			"binding": "DB",


### PR DESCRIPTION
Second pass on the private media log at `/media`.

## Worker and database

Two migrations, both already applied to the remote D1 database, and the worker is deployed:

- `0002_add_comments.sql` adds a `comments` column, with `POST /entries/:id/comments` and `DELETE /entries/:id/comments/:cid` (admin only).
- `0003_add_status.sql` adds a `status` column (`todo`, `done`) for the backlog. Existing rows default to `done`.

The metadata fetch is more reliable: HTML entities are decoded, tags are stripped before and after decoding so escaped markup cannot leak into a title, a trailing site name is removed, and the type is guessed from the source (pdf and arxiv give paper, youtube gives video, github gives repo, wikipedia gives wiki). It also returns the page description and the canonical url after redirects.

## Page

- To read backlog with a tab strip, and a `mark read` action that moves an entry to the log with today as its date.
- Comment threads per entry, rendered as a tree with an input that appears on hover.
- Sidebar where types, topics, years and ratings are both statistics and filters. Counts are faceted so selecting one value never zeroes the others, types show their average rating, and topics are packed into evenly filled rows.
- Contribution heatmap of the last twelve months: hover a day for the titles logged that day, click to filter.
- Editing happens in place in the list. The entry stays pinned if the current filters would hide it.
- The url acts as the entry identity: pasting a link already in the log shows a notice and a shortcut to edit that entry, including when a redirect resolves to it.
- Entries are cached in localStorage and revalidated in the background, so the page paints instantly and still works from the cache when the api is unreachable.
- Quick add saves a pasted link with fetched metadata in one click.
- Sort by date, rating or title, and a minimum rating filter.

## Notes

- The publication year field is gone. The read date is the only date, and the years facet counts the year read. Existing values are preserved on edit.
- Only the frontend is pending deployment. The worker and the schema are live and compatible with both the old and the new page.
