### PR TITLE
Add RSS feed at /rss.xml

### DIFF
--- a/src/library/components/footer.svelte
+++ b/src/library/components/footer.svelte
@@ -192,15 +192,14 @@
 				<ul class="list-none" style="display: flex; flex-direction: column; gap: 0.35rem;">
 					{#each linksItems as item (`footer_${item.link}`)}
 						<li>
-							<a
-								class="footer-link"
-								href={item.link}
-								data-sveltekit-preload-code="hover"
-							>
+							<a class="footer-link" href={item.link} data-sveltekit-preload-code="hover">
 								{item.label}
 							</a>
 						</li>
 					{/each}
+					<li>
+						<a class="footer-link" href="{base}/rss.xml">rss</a>
+					</li>
 				</ul>
 
 				<h4
@@ -328,7 +327,7 @@
 	/* Footer link with sweep underline */
 	.footer-link {
 		position: relative;
-		color: #9A928A;
+		color: #9a928a;
 		font-size: 0.875rem;
 		transition: color 0.2s;
 		text-decoration: none;
@@ -341,12 +340,12 @@
 		bottom: -1px;
 		width: 0;
 		height: 1px;
-		background-color: #D4A017;
+		background-color: #d4a017;
 		transition: width 0.3s ease;
 	}
 
 	.footer-link:hover {
-		color: #D4A017;
+		color: #d4a017;
 	}
 
 	.footer-link:hover::after {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,10 @@
 
 	import type { Snippet } from 'svelte';
 
-	let { data, children }: {
+	let {
+		data,
+		children
+	}: {
 		data: {
 			headerLinks: LinkItem[];
 			footerLinks: LinkItem[];
@@ -36,6 +39,12 @@
 
 <svelte:head>
 	<link rel="icon" href="{base}/favicon/favicon.png" />
+	<link
+		rel="alternate"
+		type="application/rss+xml"
+		title="Garden - Maël Lhoutellier"
+		href="{base}/rss.xml"
+	/>
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 	<link
@@ -44,16 +53,25 @@
 		crossorigin="anonymous"
 	/>
 	<title>Garden - Maël Lhoutellier</title>
-	<meta name="description" content="A digital garden of thoughts, notes, and reference guides on software engineering, math, and more." />
+	<meta
+		name="description"
+		content="A digital garden of thoughts, notes, and reference guides on software engineering, math, and more."
+	/>
 	<meta name="author" content="Maël Lhoutellier" />
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="Garden" />
 	<meta property="og:title" content="Garden - Maël Lhoutellier" />
-	<meta property="og:description" content="A digital garden of thoughts, notes, and reference guides." />
+	<meta
+		property="og:description"
+		content="A digital garden of thoughts, notes, and reference guides."
+	/>
 	<meta name="twitter:card" content="summary" />
 </svelte:head>
 
-<div class="flex min-h-screen flex-col" style="background-color: var(--color-bg); color: var(--color-text);">
+<div
+	class="flex min-h-screen flex-col"
+	style="background-color: var(--color-bg); color: var(--color-text);"
+>
 	<a
 		href="#main-content"
 		class="sr-only focus:not-sr-only focus:fixed focus:top-0 focus:left-0 focus:z-50 focus:px-4 focus:py-2"

--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -1,0 +1,79 @@
+import pagesManifest from '$meta/manifest.json';
+import type { Page } from '$types/types';
+
+// Emitted as a static file at build time, like the rest of the site.
+export const prerender = true;
+
+const SITE_URL = 'https://maellhoutellier.com';
+const SITE_TITLE = 'Garden - Maël Lhoutellier';
+const SITE_DESCRIPTION =
+	'A digital garden of thoughts, notes, and reference guides on software engineering, math, and more.';
+const MAX_ITEMS = 50;
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+function itemUrl(page: Page): string {
+	return `${SITE_URL}/${page.path.replace(/\.md$/, '')}`;
+}
+
+/** Some sheets carry no date; readers reject a malformed pubDate, so omit it. */
+function pubDate(raw: string | undefined): string | null {
+	if (!raw) return null;
+	const date = new Date(raw);
+	return Number.isNaN(date.getTime()) ? null : date.toUTCString();
+}
+
+export function GET() {
+	// Only dated content belongs in a feed: sheets and snippets are living
+	// reference pages with no publication date. Dating one adds it here.
+	const pages = (pagesManifest as Page[])
+		.filter((p) => p.meta.published !== false && pubDate(p.meta.date) !== null)
+		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
+		.slice(0, MAX_ITEMS);
+
+	const items = pages
+		.map((page) => {
+			const url = itemUrl(page);
+			const topics = page.meta.topic ? page.meta.topic.split(/\s+/).filter(Boolean) : [];
+			const date = pubDate(page.meta.date);
+			const lines = [
+				`			<title>${escapeXml(page.meta.title ?? page.meta.slug ?? 'Untitled')}</title>`,
+				`			<link>${escapeXml(url)}</link>`,
+				`			<guid isPermaLink="true">${escapeXml(url)}</guid>`,
+				...(date ? [`			<pubDate>${date}</pubDate>`] : []),
+				...(page.meta.section ? [`			<category>${escapeXml(page.meta.section)}</category>`] : []),
+				...topics.map((topic) => `			<category>${escapeXml(topic)}</category>`),
+				`			<description>${escapeXml(page.meta.short ?? '')}</description>`
+			];
+			return `		<item>\n${lines.join('\n')}\n		</item>`;
+		})
+		.join('\n');
+
+	const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>${escapeXml(SITE_TITLE)}</title>
+		<link>${SITE_URL}</link>
+		<description>${escapeXml(SITE_DESCRIPTION)}</description>
+		<language>en</language>
+		<lastBuildDate>${pubDate(pages[0]?.meta.date) ?? new Date().toUTCString()}</lastBuildDate>
+		<atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+	</channel>
+</rss>
+`;
+
+	return new Response(feed, {
+		headers: {
+			'Content-Type': 'application/xml; charset=utf-8',
+			'Cache-Control': 'public, max-age=3600'
+		}
+	});
+}


### PR DESCRIPTION
Adds a feed at `/rss.xml`, built from the content manifest at build time, so it stays a static file like the rest of the site.

- RSS 2.0 with title, link, guid, pubDate, description, and one category per section and topic.
- Only dated content is included. Articles all carry a date, while sheets and snippets are living reference pages with none, and they would show up undated and in arbitrary order in a reader. Giving one a date is enough to add it to the feed.
- Discovery link in the document head, plus an `rss` link in the footer navigation.
- Capped at 50 items, absolute urls on `https://maellhoutellier.com`.

Checked the built file with an XML parser: well formed, 7 items, newest first, every date parseable as RFC 822, every link absolute, and the private media log is absent.
